### PR TITLE
fix circular dependency by importing context directly

### DIFF
--- a/src/components/state/hooks/useAggregator.ts
+++ b/src/components/state/hooks/useAggregator.ts
@@ -10,7 +10,9 @@
  */
 
 import { useContext, useCallback } from 'react';
-import { AggregatorContext } from '../context';
+// Importing the context directly avoids pulling in the provider
+// which would create a circular dependency during the build.
+import { AggregatorContext } from '../context/aggregatorContext';
 import { OverlayCard, Channel, OverlayState } from '../types';
 
 /**


### PR DESCRIPTION
## Summary
- import `AggregatorContext` directly to avoid including the provider
- resolve circular dependency warning in build

## Testing
- `npm run build`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684049c4de8483298e0f738be9c6ddef