### PR TITLE
Fix example module resolution for floatify

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -14,7 +14,11 @@
         "skipLibCheck": true, // Speeds up compilation by skipping library type checking
         "jsx": "react-jsx", // Enables JSX support (for React 18)
         "lib": ["ESNext", "DOM"], // Supports latest JavaScript features & DOM APIs
-        "types": ["node"] // Ensures Node.js module types are available
+        "types": ["node"], // Ensures Node.js module types are available
+        "baseUrl": ".", // Needed for path alias to work
+        "paths": {
+            "floatify": ["../src"]
+        }
     },
     "include": ["src"], // Only compile files in `src/`
     "exclude": ["node_modules", "dist", "example", "tests"] // Ignore these directories

--- a/example/vite.config.mjs
+++ b/example/vite.config.mjs
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from 'node:url';
 
 export default defineConfig({
     plugins: [react()],
+    resolve: {
+        alias: {
+            floatify: fileURLToPath(new URL('../src', import.meta.url)),
+        },
+    },
     server: {
         port: 5173,
     },


### PR DESCRIPTION
## Summary
- alias `floatify` to the local `src` folder so the example runs without npm link
- update example tsconfig to recognize the alias

## Testing
- `npm install`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684054007c348329b8f15a790aab8db9