### PR TITLE
Enhance dynamic island styling

### DIFF
--- a/src/components/style/components/overlay-card.css
+++ b/src/components/style/components/overlay-card.css
@@ -22,7 +22,9 @@
     user-select: none;
 
     transition: width var(--di-duration-normal) var(--di-spring-timing), height var(--di-duration-normal) var(--di-spring-timing),
-        transform var(--di-duration-fast) var(--di-transition-timing), opacity var(--di-duration-fast) var(--di-transition-timing);
+        transform var(--di-duration-fast) var(--di-transition-timing), opacity var(--di-duration-fast) var(--di-transition-timing),
+        box-shadow 0.3s var(--di-transition-timing), background-color 0.15s ease-in-out,
+        backdrop-filter 0.2s ease-in-out;
     will-change: width, height, transform, opacity;
 }
 

--- a/src/components/style/components/overlay-portal.css
+++ b/src/components/style/components/overlay-portal.css
@@ -19,8 +19,13 @@
     cursor: pointer;
     z-index: var(--di-z-index, 9999);
     will-change: transform, width, height, opacity, visibility;
+    background-color: rgba(var(--di-background-rgb, 18, 18, 18), var(--di-glass-opacity, 0.75));
+    backdrop-filter: blur(var(--di-glass-blur, 16px));
+    -webkit-backdrop-filter: blur(var(--di-glass-blur, 16px));
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
     transition: width 0.3s var(--di-transition-timing), height 0.3s var(--di-transition-timing), transform 0.3s var(--di-transition-timing),
-        opacity 0.2s ease-out, visibility 0s linear, background-color 0.15s ease-in-out, backdrop-filter 0.15s ease-in-out;
+        opacity 0.2s ease-out, visibility 0s linear, background-color 0.15s ease-in-out, backdrop-filter 0.15s ease-in-out,
+        box-shadow 0.3s var(--di-transition-timing), border-radius 0.3s var(--di-transition-timing);
 }
 
 /* Focus ring for accessibility */

--- a/src/components/style/core/animations.css
+++ b/src/components/style/core/animations.css
@@ -6,11 +6,18 @@
 
 /* 🔹 Expand Animation */
 @keyframes overlay-expand {
-    from {
+    0% {
         transform: translateX(-50%) scale(0.95);
         opacity: 0.8;
     }
-    to {
+    60% {
+        transform: translateX(-50%) scale(1.05);
+        opacity: 1;
+    }
+    80% {
+        transform: translateX(-50%) scale(0.98);
+    }
+    100% {
         transform: translateX(-50%) scale(1);
         opacity: 1;
     }
@@ -18,10 +25,13 @@
 
 /* 🔹 Collapse Animation */
 @keyframes overlay-collapse {
-    from {
+    0% {
         transform: translateX(-50%) scale(1);
     }
-    to {
+    30% {
+        transform: translateX(-50%) scale(1.02);
+    }
+    100% {
         transform: translateX(-50%) scale(0.95);
     }
 }

--- a/src/components/style/themes/full-theme.css
+++ b/src/components/style/themes/full-theme.css
@@ -70,6 +70,18 @@ html {
     -webkit-backdrop-filter: blur(var(--di-glass-blur));
 }
 
+/* 🌟 Portal Styling */
+.overlay-styled .overlay-portal {
+    background-color: var(--di-background);
+    color: var(--di-text);
+    box-shadow: 0 8px 24px var(--di-shadow);
+    border: 1px solid var(--di-glass-border);
+    backdrop-filter: blur(var(--di-glass-blur));
+    -webkit-backdrop-filter: blur(var(--di-glass-blur));
+    transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out,
+        border-color 0.2s ease-in-out;
+}
+
 /* 🔆 Light Theme Overrides */
 [data-theme='light'] .overlay-styled .overlay-card {
     background-color: var(--di-background);


### PR DESCRIPTION
## Summary
- polish overlay portal with glassmorphism and smooth transitions
- add box-shadow and backdrop-filter transitions to overlay cards
- tweak expand/collapse animations for a bounce effect
- theme overlay portal for consistent glass style

## Testing
- `npm test -- -t ''`

------
https://chatgpt.com/codex/tasks/task_e_6841498f4b7c8329ae2a6b80c58ed47a