### PR TITLE
Animate overlay portal size based on state

### DIFF
--- a/src/components/core/portal/OverlayPortal.tsx
+++ b/src/components/core/portal/OverlayPortal.tsx
@@ -69,7 +69,7 @@ function DefaultOverlay({ channelId, cardId }: { channelId: string; cardId: stri
 
     return (
         <div className="overlay-container">
-            <div className="overlay-portal">
+            <div className="overlay-portal" data-state={channel.state}>
                 <DefaultCardUI
                     channelId={channelId}
                     card={card}

--- a/src/components/style/components/overlay-portal.css
+++ b/src/components/style/components/overlay-portal.css
@@ -28,6 +28,17 @@
         box-shadow 0.3s var(--di-transition-timing), border-radius 0.3s var(--di-transition-timing);
 }
 
+/* State-based sizing to mirror the overlay card */
+.overlay-styled .overlay-portal[data-state='expanded'] {
+    width: var(--overlay-expanded-width, 350px);
+    height: var(--overlay-expanded-height, 120px);
+}
+
+.overlay-styled .overlay-portal[data-state='collapsed'] {
+    width: var(--overlay-collapsed-width, 120px);
+    height: var(--overlay-collapsed-height, 36px);
+}
+
 /* Focus ring for accessibility */
 .overlay-styled .overlay-portal:focus-visible {
     outline: 2px solid var(--overlay-focus-ring, rgba(0, 122, 255, 0.8));


### PR DESCRIPTION
## Summary
- expose `data-state` on DefaultOverlay portal
- animate portal sizing for expanded/collapsed states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841583eb3e88329b8463bd0fb1aa2f4