### PR TITLE
Improve debug logging wrapper with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ function App() {
 }
 ```
 
+## Debug Mode
+
+Enable debug logging by passing the `debug` prop to `Floatify` or
+`AggregatorProvider`:
+
+```tsx
+<Floatify debug>
+  {/* rest of your app */}
+</Floatify>
+```
+
+The console will group each dispatched action with the previous state,
+the action object and the next state, helping you trace overlay updates.
+
 ## Running the Example Project
 
 The `example` folder contains a small React app that demonstrates Floatify in action. After running the steps in the *Linking the local build* section above, visit `http://localhost:5173` to see overlays appear on timed intervals.

--- a/tests/AggregatorProvider.debug.test.tsx
+++ b/tests/AggregatorProvider.debug.test.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react/pure';
+import AggregatorProvider from '../src/components/state/context/aggregatorProvider';
+import useAggregator from '../src/components/state/hooks/useAggregator';
+
+function DispatchOnMount() {
+    const { registerChannel } = useAggregator();
+    useEffect(() => {
+        registerChannel('ch', 1);
+    }, [registerChannel]);
+    return null;
+}
+
+describe('AggregatorProvider debug logging', () => {
+    it('logs action and state transitions when debug is enabled', () => {
+        const groupSpy = vi.spyOn(console, 'groupCollapsed').mockImplementation(() => {});
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        render(
+            <AggregatorProvider debug>
+                <DispatchOnMount />
+            </AggregatorProvider>
+        );
+        expect(groupSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledTimes(3);
+        logSpy.mockRestore();
+        groupSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- expand docs for debug flag in README and provider code
- group console output and show prev/next state in debug mode
- adjust debug logging test for new output

## Testing
- `npm test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6841589672c883299226abc464f117ea