### PR TITLE
Add router-based example docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A flexible overlay and notification library for React.
 
 Floatify helps you display transient UI elements like toasts, alerts or walkthrough cards without cluttering your component tree. It manages multiple overlay channels through a central **AggregatorProvider** so that cards can be queued, swiped or dismissed from anywhere in your app.
 
+For a full guide with code snippets and live demos, open the React docs app under [`example/`](example/index.html). It showcases all mods and links to the roadmap.
+
 ## Key Features
 
 - **Aggregator provider** for global overlay state management and concurrency modes.
@@ -77,7 +79,17 @@ the action object and the next state, helping you trace overlay updates.
 
 ## Running the Example Project
 
-The `example` folder contains a small React app that demonstrates Floatify in action. After running the steps in the *Linking the local build* section above, visit `http://localhost:5173` to see overlays appear on timed intervals.
+The `example` folder doubles as the documentation site. After running the steps in the *Linking the local build* section above, run `npm run dev` inside `example` and visit `http://localhost:5173` to explore the docs and interactive demos.
+
+## Roadmap
+
+Upcoming development plans are tracked in [ROADMAP.md](ROADMAP.md). Highlights include:
+
+- Bringing the package to a stable 1.0 release
+- Adding a notification history panel
+- Improved default styles and themes
+- Different ways to open the history panel via icons or links
+- More dynamic-island style interactions
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,19 @@
+# Floatify Roadmap
+
+This document outlines upcoming development plans for the Floatify library.
+
+## Near Term
+
+- **Stability** – Finalise the API and publish a stable 1.0 release.
+- **Notification history** – Provide a panel to browse previous cards.
+- **Styling improvements** – Polish the default themes and allow easier customization.
+- **Panel triggers** – Offer built‑in icons or links to open the history panel.
+
+## Future Ideas
+
+- Richer interactions inspired by mobile "dynamic island" widgets.
+- Animation presets for card transitions.
+- Pluggable renderers so cards can display custom content.
+- Accessibility improvements and more keyboard navigation options.
+- Progress indicators for long running tasks.
+- Integration with web notifications for push messages.

--- a/example/index.html
+++ b/example/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Floatify Example</title>
-    </head>
-    <body>
-        <div id="root"></div>
-        <script type="module" src="/src/main.tsx"></script>
-    </body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Floatify Docs & Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -12,7 +12,8 @@
         "floatify": "file:..",
         "lucide-react": "^0.482.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
@@ -765,6 +766,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.35.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.35.0.tgz",
@@ -1381,6 +1391,38 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/rollup": {

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,8 @@
     "lucide-react": "^0.482.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "floatify": "file:.."
+    "floatify": "file:..",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,154 +1,36 @@
-import React, { useState, useEffect } from 'react';
-import { Floatify, useAggregator } from 'floatify'; // Importing Floatify
+import React, { useEffect, useState } from 'react';
+import { Floatify } from 'floatify';
+import { Routes, Route } from 'react-router-dom';
+import NavBar from './components/NavBar';
+import Home from './pages/Home';
+import Examples from './pages/Examples';
+import Roadmap from './pages/Roadmap';
 import './index.css';
-import { Sun, Moon } from 'lucide-react';
 
-function AppContent() {
-    const [theme, setTheme] = useState(() => {
-        const savedTheme = localStorage.getItem('theme');
-        return savedTheme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-    });
+export default function App() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    const saved = localStorage.getItem('theme') as 'light' | 'dark' | null;
+    return saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  });
 
-    // 1) Access aggregator actions to register a channel & add/remove cards
-    const { registerChannel, addCard, removeCard } = useAggregator();
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
 
-    useEffect(() => {
-        document.documentElement.setAttribute('data-theme', theme);
-        localStorage.setItem('theme', theme);
-    }, [theme]);
+  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
 
-    // 2) On mount, set up a test channel and schedule timed actions
-    useEffect(() => {
-        // Register a couple of channels (priority=1)
-        registerChannel('testChannel', 1);
-        registerChannel('infoChannel', 1);
-
-        // After 5 seconds, add a first card
-        const timer1 = setTimeout(() => {
-            addCard('testChannel', {
-                id: 'card-1',
-                title: 'Hello from Card 1',
-                content: 'This card appears after 5 seconds',
-                // iconUrl: '...' if you want an icon
-            });
-            console.log('Added card-1 to testChannel');
-        }, 5000);
-
-        // After 8 seconds, add a second card
-        const timer2 = setTimeout(() => {
-            addCard('testChannel', {
-                id: 'card-2',
-                title: 'Another Card',
-                content: 'Second card in the channel, at 8 seconds',
-            });
-            console.log('Added card-2 to testChannel');
-        }, 8000);
-
-        // After 6 seconds, add a card to the secondary channel
-        const timerInfo = setTimeout(() => {
-            addCard('infoChannel', {
-                id: 'info-1',
-                title: 'Secondary Channel',
-                content: 'Card from another channel',
-            });
-            console.log('Added info-1 to infoChannel');
-        }, 6000);
-
-        // After 13 seconds, remove the first card
-        const timer3 = setTimeout(() => {
-            removeCard('testChannel', 'card-1');
-            console.log('Removed card-1 from testChannel');
-        }, 13000);
-
-        return () => {
-            clearTimeout(timer1);
-            clearTimeout(timer2);
-            clearTimeout(timerInfo);
-            clearTimeout(timer3);
-        };
-    }, [registerChannel, addCard, removeCard]);
-
-    const toggleTheme = () => {
-        setTheme(theme === 'dark' ? 'light' : 'dark');
-    };
-    const isDark = theme === 'dark';
-
-    return (
-        <div
-            style={{
-                minHeight: '100vh',
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                padding: '120px 20px 40px',
-                backgroundColor: isDark ? '#000' : '#f5f5f5',
-                color: isDark ? '#fff' : '#1a1a1a',
-                gap: '2rem',
-                transition: 'background-color 0.3s, color 0.3s',
-            }}
-        >
-            <button
-                onClick={toggleTheme}
-                style={{
-                    position: 'fixed',
-                    top: '20px',
-                    right: '20px',
-                    padding: '12px',
-                    background: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)',
-                    border: 'none',
-                    borderRadius: '50%',
-                    cursor: 'pointer',
-                    color: isDark ? '#fff' : '#000',
-                    transition: 'all 0.3s ease',
-                }}
-            >
-                {isDark ? <Sun size={20} /> : <Moon size={20} />}
-            </button>
-
-            <div
-                style={{
-                    maxWidth: '600px',
-                    margin: '2rem auto',
-                    padding: '2rem',
-                    background: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)',
-                    borderRadius: '20px',
-                    backdropFilter: 'blur(10px)',
-                    border: `1px solid ${isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)'}`,
-                }}
-            >
-                <h2
-                    style={{
-                        fontSize: '1.5rem',
-                        fontWeight: 'bold',
-                        marginBottom: '1.5rem',
-                        textAlign: 'center',
-                    }}
-                >
-                    Overlay Test
-                </h2>
-                <p>
-                    This demo automatically registers a <strong>testChannel</strong> and adds cards at timed intervals (5s, 8s, and removes one at
-                    13s).
-                </p>
-                <p>
-                    Check the console for logs, or watch for overlay pop-ups if you have an
-                    <strong> OverlayPortal</strong> rendering them.
-                </p>
-            </div>
-        </div>
-    );
+  return (
+    <Floatify concurrencyMode="multiple" debug>
+      <NavBar theme={theme} onToggleTheme={toggleTheme} />
+      <main>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/examples" element={<Examples />} />
+          <Route path="/roadmap" element={<Roadmap />} />
+        </Routes>
+      </main>
+      {/* Add <OverlayPortal /> here if you have one */}
+    </Floatify>
+  );
 }
-
-// Main App wraps everything in the aggregator provider
-function App() {
-    return (
-        <Floatify concurrencyMode="multiple" debug>
-            <AppContent />
-            {/* If you have a portal component, add it here:
-            <OverlayPortal concurrencyMode="multiple" />
-        */}
-        </Floatify>
-    );
-}
-
-export default App;

--- a/example/src/components/Demo.tsx
+++ b/example/src/components/Demo.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from 'react';
+import { useAggregator } from 'floatify';
+
+export default function Demo() {
+  const { registerChannel, addCard, removeCard } = useAggregator();
+
+  useEffect(() => {
+    registerChannel('test', 1);
+    registerChannel('info', 1);
+
+    const t1 = setTimeout(() => {
+      addCard('test', {
+        id: 'c1',
+        title: 'Hello from Card 1',
+        content: 'Appears after 3 seconds',
+      });
+    }, 3000);
+
+    const t2 = setTimeout(() => {
+      addCard('info', {
+        id: 'i1',
+        title: 'Another Channel',
+        content: 'This one shows on the info channel',
+      });
+    }, 6000);
+
+    const t3 = setTimeout(() => {
+      removeCard('test', 'c1');
+    }, 10000);
+
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [registerChannel, addCard, removeCard]);
+
+  return <p>Watch for overlays appearing after a few seconds.</p>;
+}

--- a/example/src/components/NavBar.tsx
+++ b/example/src/components/NavBar.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import ThemeToggle from './ThemeToggle';
+
+interface Props {
+  theme: 'light' | 'dark';
+  onToggleTheme: () => void;
+}
+
+export default function NavBar({ theme, onToggleTheme }: Props) {
+  return (
+    <nav>
+      <NavLink to="/" end>
+        Overview
+      </NavLink>
+      <NavLink to="/examples">Examples</NavLink>
+      <NavLink to="/roadmap">Roadmap</NavLink>
+      <ThemeToggle theme={theme} onToggle={onToggleTheme} />
+    </nav>
+  );
+}

--- a/example/src/components/ThemeToggle.tsx
+++ b/example/src/components/ThemeToggle.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Sun, Moon } from 'lucide-react';
+
+interface Props {
+  theme: 'light' | 'dark';
+  onToggle: () => void;
+}
+
+export default function ThemeToggle({ theme, onToggle }: Props) {
+  return (
+    <button
+      onClick={onToggle}
+      aria-label="Toggle theme"
+      style={{ background: 'none', border: 'none' }}
+    >
+      {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  );
+}

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -11,7 +11,8 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    background-color: #f5f5f5;
+    background-color: var(--bg, #f5f5f5);
+    --nav-bg: rgba(245, 245, 245, 0.8);
 }
 
 #root {
@@ -33,6 +34,59 @@ button {
 
 button:active {
     transform: scale(0.98);
+}
+
+nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    background: var(--nav-bg, rgba(245, 245, 245, 0.8));
+    border-bottom: 1px solid #ddd;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    z-index: 10;
+}
+
+nav a {
+    text-decoration: none;
+    color: var(--text, #333);
+    font-weight: 600;
+}
+
+nav a.active {
+    text-decoration: underline;
+}
+
+main {
+    padding: 100px 20px 40px;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+section {
+    margin-bottom: 2rem;
+}
+
+pre {
+    background: rgba(0, 0, 0, 0.05);
+    padding: 1rem;
+    overflow-x: auto;
+    border-radius: 8px;
+}
+
+code {
+    font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Ubuntu Mono", monospace;
+}
+
+[data-theme='dark'] {
+    --bg: #000;
+    --text: #fff;
+    --nav-bg: rgba(0, 0, 0, 0.6);
 }
 
 /* Accessibility */

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-    <React.StrictMode>
-        <App />
-    </React.StrictMode>
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
 );

--- a/example/src/pages/Examples.tsx
+++ b/example/src/pages/Examples.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Demo from '../components/Demo';
+
+const quickStart = `import { Floatify, useAggregator } from 'floatify';
+
+function App() {
+  const { registerChannel, addCard } = useAggregator();
+
+  useEffect(() => {
+    registerChannel('alerts', 1);
+    addCard('alerts', { id: 'welcome', title: 'Hello', content: 'Welcome!' });
+  }, []);
+
+  return <Floatify concurrencyMode="multiple">{/* app */}</Floatify>;
+}`;
+
+export default function Examples() {
+  return (
+    <section>
+      <h2>Quick Start</h2>
+      <pre>
+        <code>{quickStart}</code>
+      </pre>
+      <h2>Demo</h2>
+      <Demo />
+    </section>
+  );
+}

--- a/example/src/pages/Home.tsx
+++ b/example/src/pages/Home.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function Home() {
+  return (
+    <section>
+      <h2>Overview</h2>
+      <p>
+        Floatify lets you display transient UI like toasts or guided cards using a
+        global provider.
+      </p>
+      <h2>Installation</h2>
+      <pre>
+        <code>npm install floatify</code>
+      </pre>
+    </section>
+  );
+}

--- a/example/src/pages/Roadmap.tsx
+++ b/example/src/pages/Roadmap.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function Roadmap() {
+  return (
+    <section>
+      <h2>Roadmap</h2>
+      <ul>
+        <li>Stabilise the API for a 1.0 release</li>
+        <li>Add a notification history panel</li>
+        <li>Improve default styles and themes</li>
+        <li>Offer icons or links to open the history panel</li>
+        <li>More dynamic-island style interactions</li>
+        <li>Progress indicators for long running tasks</li>
+        <li>Integration with web notifications for push messages</li>
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- expand roadmap
- add React Router and modular components for the example docs app
- implement theme toggle and navigation with a dynamic island vibe

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684176efca74832986d6fab64d209f0d