### PR TITLE
Add configurable island variables

### DIFF
--- a/src/components/style/components/overlay-actions.css
+++ b/src/components/style/components/overlay-actions.css
@@ -18,7 +18,7 @@
     cursor: pointer;
     font-size: 18px;
     padding: var(--overlay-padding-sm);
-    color: var(--overlay-text-color);
+    color: var(--di-text);
     transition: var(--overlay-transition);
 }
 
@@ -30,10 +30,10 @@
 .overlay-styled .overlay-card-swipe-prev,
 .overlay-styled .overlay-card-swipe-next {
     background: var(--overlay-primary-color);
-    color: white;
+    color: var(--di-text);
     font-size: var(--overlay-font-size-md);
     padding: var(--overlay-padding-sm) var(--overlay-padding-md);
-    border-radius: var(--overlay-border-radius);
+    border-radius: var(--di-border-radius);
     cursor: pointer;
     transition: var(--overlay-transition);
 }

--- a/src/components/style/components/overlay-card.css
+++ b/src/components/style/components/overlay-card.css
@@ -4,14 +4,17 @@
    - Ensures accessibility, responsiveness, and animations
 ========================================================== */
 
+
 .overlay-styled .overlay-card {
-    background-color: var(--di-background);
+    background-color: rgba(var(--di-background-rgb), var(--di-glass-opacity));
     color: var(--di-text);
     font-size: var(--overlay-font-size-md);
     padding: var(--overlay-padding-md);
-    border-radius: var(--overlay-border-radius);
+    border-radius: var(--di-border-radius);
     box-shadow: var(--di-shadow);
     border: var(--di-glass-border) solid 1px;
+    backdrop-filter: blur(var(--di-glass-blur));
+    -webkit-backdrop-filter: blur(var(--di-glass-blur));
     width: fit-content;
     max-width: 350px;
     display: flex;
@@ -39,6 +42,7 @@
     overflow: hidden;
     padding: var(--overlay-padding-sm);
     animation: overlay-collapse var(--di-duration-normal) var(--di-transition-timing);
+    border-radius: calc(var(--overlay-collapsed-height) / 2);
 }
 
 /* 🔹 Expanded Mode */
@@ -48,6 +52,7 @@
     padding: var(--overlay-padding-lg);
     justify-content: space-between;
     animation: overlay-expand var(--di-duration-normal) var(--di-transition-timing);
+    border-radius: var(--di-border-radius);
 }
 
 /* 🔹 Title Styling */

--- a/src/components/style/components/overlay-portal.css
+++ b/src/components/style/components/overlay-portal.css
@@ -10,17 +10,17 @@
     transform: none;
     width: var(--overlay-collapsed-width);
     height: var(--overlay-collapsed-height);
-    color: var(--di-text, #fff);
+    color: var(--di-text);
 
-    border-radius: var(--overlay-border-radius);
+    border-radius: calc(var(--overlay-collapsed-height) / 2);
     overflow: hidden;
     user-select: none;
     cursor: pointer;
     z-index: var(--di-z-index, 9999);
     will-change: transform, width, height, opacity, visibility;
-    background-color: rgba(var(--di-background-rgb, 18, 18, 18), var(--di-glass-opacity, 0.75));
-    backdrop-filter: blur(var(--di-glass-blur, 16px));
-    -webkit-backdrop-filter: blur(var(--di-glass-blur, 16px));
+    background-color: rgba(var(--di-background-rgb), var(--di-glass-opacity));
+    backdrop-filter: blur(var(--di-glass-blur));
+    -webkit-backdrop-filter: blur(var(--di-glass-blur));
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
     transition: width 0.3s var(--di-transition-timing), height 0.3s var(--di-transition-timing), transform 0.3s var(--di-transition-timing),
         opacity 0.2s ease-out, visibility 0s linear, background-color 0.15s ease-in-out, backdrop-filter 0.15s ease-in-out,
@@ -31,11 +31,13 @@
 .overlay-styled .overlay-portal[data-state='expanded'] {
     width: var(--overlay-expanded-width, 350px);
     height: var(--overlay-expanded-height, 120px);
+    border-radius: var(--di-border-radius);
 }
 
 .overlay-styled .overlay-portal[data-state='collapsed'] {
     width: var(--overlay-collapsed-width, 120px);
     height: var(--overlay-collapsed-height, 36px);
+    border-radius: calc(var(--overlay-collapsed-height) / 2);
 }
 
 /* Focus ring for accessibility */

--- a/src/components/style/core/variables.css
+++ b/src/components/style/core/variables.css
@@ -36,6 +36,9 @@
     --overlay-gap-md: 8px;
     --overlay-gap-lg: 12px;
     --overlay-border-radius: 12px;
+    /* Dynamic Island Defaults */
+    --di-border-radius: var(--overlay-border-radius);
+    --di-glass-opacity: 0.75;
 
     /* Shadows */
     --overlay-shadow-sm: 0px 2px 5px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- expose `--di-border-radius` and `--di-glass-opacity` in global variables
- use new variables in overlay card and portal styles
- adjust card action styles to use new tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418b9dfbc48329b687780d13bba282