### PR TITLE
Make portal container invisible

### DIFF
--- a/src/components/style/components/overlay-portal.css
+++ b/src/components/style/components/overlay-portal.css
@@ -18,10 +18,11 @@
     cursor: pointer;
     z-index: var(--di-z-index, 9999);
     will-change: transform, width, height, opacity, visibility;
-    background-color: rgba(var(--di-background-rgb), var(--di-glass-opacity));
-    backdrop-filter: blur(var(--di-glass-blur));
-    -webkit-backdrop-filter: blur(var(--di-glass-blur));
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
     transition: width 0.3s var(--di-transition-timing), height 0.3s var(--di-transition-timing), transform 0.3s var(--di-transition-timing),
         opacity 0.2s ease-out, visibility 0s linear, background-color 0.15s ease-in-out, backdrop-filter 0.15s ease-in-out,
         box-shadow 0.3s var(--di-transition-timing), border-radius 0.3s var(--di-transition-timing);

--- a/src/components/style/themes/full-theme.css
+++ b/src/components/style/themes/full-theme.css
@@ -72,12 +72,12 @@ html {
 
 /* 🌟 Portal Styling */
 .overlay-styled .overlay-portal {
-    background-color: var(--di-background);
-    color: var(--di-text);
-    box-shadow: 0 8px 24px var(--di-shadow);
-    border: 1px solid var(--di-glass-border);
-    backdrop-filter: blur(var(--di-glass-blur));
-    -webkit-backdrop-filter: blur(var(--di-glass-blur));
+    background-color: transparent;
+    box-shadow: none;
+    border: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    color: inherit;
     transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out,
         border-color 0.2s ease-in-out;
 }


### PR DESCRIPTION
## Summary
- make the portal container transparent so only the card is visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418e4c81ec8329839c45550eb2d037