### PR TITLE
Improve overlay states and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,29 @@ The overlay portal can stick to the viewport and be positioned around the screen
 On mobile devices only `top` or `bottom` positions are recommended.
 
 ```tsx
-<Floatify sticky position="bottom-right">
+<Floatify sticky position="bottom">
   {/* rest of your app */}
 </Floatify>
+```
+
+### Loading & Icon States
+
+Set a channel to `'loading'` to show a spinner or `'icon'` to display just the icon.
+A typical pattern is to drive this from a loading boolean:
+
+```tsx
+const { registerChannel, updateChannelState } = useAggregator();
+const [loading, setLoading] = useState(true);
+
+useEffect(() => {
+  registerChannel('playback', 1);
+}, [registerChannel]);
+
+useEffect(() => {
+  updateChannelState('playback', loading ? 'loading' : 'collapsed');
+}, [loading, updateChannelState]);
+
+// later: setLoading(false); updateChannelState('playback', 'icon');
 ```
 
 ## Debug Mode

--- a/src/components/core/LoadingIndicator.tsx
+++ b/src/components/core/LoadingIndicator.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import '../style/components/loading-indicator.css';
+
+export default function LoadingIndicator() {
+    return (
+        <div className="loading-indicator" role="status" aria-label="Loading">
+            <div className="loading-spinner" />
+        </div>
+    );
+}

--- a/src/components/state/reducers/aggregatorReducer.ts
+++ b/src/components/state/reducers/aggregatorReducer.ts
@@ -95,7 +95,7 @@ export function aggregatorReducer(state: OverlayAggregatorState, action: Overlay
             };
 
             // Optional concurrency example:
-            // If a card is added to a higher-priority channel, switch active?
+            // If a card is added to a higher-priority channel, switch active
             if (action.type === 'ADD_CARD') {
                 const newChannelPriority = updatedChannel.priority;
                 const currentActive = nextState.activeChannelId ? nextState.channels[nextState.activeChannelId] : null;
@@ -107,6 +107,20 @@ export function aggregatorReducer(state: OverlayAggregatorState, action: Overlay
                         ...nextState,
                         activeChannelId: channelId,
                     };
+                }
+            }
+
+            if (action.type === 'UPDATE_CHANNEL_STATE') {
+                const { newState } = action.payload;
+                if (newState !== 'hidden') {
+                    const currentActive = nextState.activeChannelId ? nextState.channels[nextState.activeChannelId] : null;
+                    const isHigherPriority =
+                        !currentActive || updatedChannel.priority > currentActive.priority;
+                    if (isHigherPriority) {
+                        nextState = { ...nextState, activeChannelId: channelId };
+                    }
+                } else if (nextState.activeChannelId === channelId) {
+                    nextState = { ...nextState, activeChannelId: null };
                 }
             }
 

--- a/src/components/state/reducers/channelReducer.ts
+++ b/src/components/state/reducers/channelReducer.ts
@@ -54,7 +54,10 @@ export function channelReducer(channel: Channel, action: OverlayAggregatorAction
 
         case 'UPDATE_CHANNEL_STATE': {
             if (action.payload.channelId !== channel.channelId) return channel;
+
+            // All valid overlay states are passed directly.
             const { newState } = action.payload;
+
             return {
                 ...channel,
                 state: newState,

--- a/src/components/state/types/channelTypes.ts
+++ b/src/components/state/types/channelTypes.ts
@@ -10,7 +10,14 @@ import { OverlayCard } from './overlayCardTypes';
 /**
  * OverlayState indicates the current display/interaction mode for a channel.
  */
-export type OverlayState = 'hidden' | 'collapsed' | 'expanded' | 'alert' | 'swiping';
+export type OverlayState =
+    | 'hidden'
+    | 'collapsed'
+    | 'expanded'
+    | 'alert'
+    | 'swiping'
+    | 'loading'
+    | 'icon';
 
 /**
  * Channel represents a distinct data stream in the overlay system

--- a/src/components/state/types/overlayAggregatorActions.ts
+++ b/src/components/state/types/overlayAggregatorActions.ts
@@ -40,7 +40,9 @@ export type OverlayAggregatorAction =
       }
 
     /**
-     * Update the overlay state (collapsed, expanded, swiping, etc.) of a channel.
+     * Update the overlay state of a channel.
+     * Supported states: 'hidden', 'collapsed', 'expanded', 'alert',
+     * 'swiping', 'loading', and 'icon'.
      */
     | {
           type: 'UPDATE_CHANNEL_STATE';

--- a/src/components/style/components/loading-indicator.css
+++ b/src/components/style/components/loading-indicator.css
@@ -1,0 +1,25 @@
+.loading-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--overlay-collapsed-height, 36px);
+    height: var(--overlay-collapsed-height, 36px);
+}
+
+.loading-spinner {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 3px solid rgba(0, 0, 0, 0.2);
+    border-top-color: var(--overlay-primary-color);
+    animation: loading-spin 1s linear infinite;
+}
+
+@keyframes loading-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/components/style/components/overlay-card.css
+++ b/src/components/style/components/overlay-card.css
@@ -44,6 +44,19 @@
     border-radius: calc(var(--overlay-collapsed-height) / 2);
 }
 
+/* 🔹 Loading / Icon Only Modes */
+.overlay-styled .overlay-card--loading,
+.overlay-styled .overlay-card--icon {
+    width: var(--overlay-collapsed-height, 36px);
+    height: var(--overlay-collapsed-height, 36px);
+    min-width: var(--overlay-collapsed-height, 36px);
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: calc(var(--overlay-collapsed-height, 36px) / 2);
+}
+
 /* 🔹 Expanded Mode */
 .overlay-styled .overlay-card--expanded {
     width: var(--overlay-expanded-width, 350px);

--- a/src/components/style/components/overlay-portal.css
+++ b/src/components/style/components/overlay-portal.css
@@ -116,41 +116,51 @@
 /* ------------------------------------------------------------------
    Position helpers for the overlay portal
    ------------------------------------------------------------------ */
-.overlay-portal--sticky {
+
+.overlay-styled .overlay-portal--sticky {
     position: sticky;
     top: 0;
 }
 
-@media (min-width: 481px) {
-    .overlay-portal--top {
-        position: fixed;
-        top: 0;
-        left: 50%;
-        transform: translateX(-50%);
-    }
+/* Mobile friendly placement */
+.overlay-styled .overlay-portal--top {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+}
 
-    .overlay-portal--bottom {
+.overlay-styled .overlay-portal--bottom {
+    position: fixed;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+@media (min-width: 481px) {
+
+    .overlay-styled .overlay-portal--bottom {
         position: fixed;
         bottom: 0;
         left: 50%;
         transform: translateX(-50%);
     }
 
-    .overlay-portal--center {
+    .overlay-styled .overlay-portal--center {
         position: fixed;
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
     }
 
-    .overlay-portal--top-left {
+    .overlay-styled .overlay-portal--top-left {
         position: fixed;
         top: 0;
         left: 0;
         transform: none;
     }
 
-    .overlay-portal--top-right {
+    .overlay-styled .overlay-portal--top-right {
         position: fixed;
         top: 0;
         right: 0;
@@ -158,14 +168,14 @@
         transform: none;
     }
 
-    .overlay-portal--bottom-left {
+    .overlay-styled .overlay-portal--bottom-left {
         position: fixed;
         bottom: 0;
         left: 0;
         transform: none;
     }
 
-    .overlay-portal--bottom-right {
+    .overlay-styled .overlay-portal--bottom-right {
         position: fixed;
         bottom: 0;
         right: 0;

--- a/src/components/style/index.css
+++ b/src/components/style/index.css
@@ -10,5 +10,6 @@
 @import './components/overlay-portal.css';
 @import './components/overlay-card.css';
 @import './components/overlay-actions.css';
+@import './components/loading-indicator.css';
 
 @import './themes/full-theme.css';

--- a/tests/OverlayStates.test.tsx
+++ b/tests/OverlayStates.test.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect } from 'react';
+import { render, screen } from '@testing-library/react/pure';
+import { describe, it, expect } from 'vitest';
+import AggregatorProvider from '../src/components/state/context/aggregatorProvider';
+import useAggregator from '../src/components/state/hooks/useAggregator';
+
+function LoadingSetup() {
+    const { registerChannel, updateChannelState } = useAggregator();
+    useEffect(() => {
+        registerChannel('load', 1);
+        updateChannelState('load', 'loading');
+    }, [registerChannel, updateChannelState]);
+    return null;
+}
+
+function PositionSetup() {
+    const { registerChannel, addCard } = useAggregator();
+    useEffect(() => {
+        registerChannel('ch', 1);
+        addCard('ch', { id: 'a', content: 'A' });
+    }, [registerChannel, addCard]);
+    return null;
+}
+
+describe('overlay additional states', () => {
+    it('renders spinner when loading', () => {
+        render(
+            <AggregatorProvider>
+                <LoadingSetup />
+            </AggregatorProvider>
+        );
+        expect(screen.getByLabelText('Loading')).toBeTruthy();
+    });
+
+    it('applies position class', () => {
+        render(
+            <AggregatorProvider position="top">
+                <PositionSetup />
+            </AggregatorProvider>
+        );
+        const portal = document.querySelector('.overlay-portal');
+        expect(portal?.classList.contains('overlay-portal--top')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- add a reusable `LoadingIndicator` component
- support `loading` and `icon` channel states
- adjust portal positioning rules for consistent specificity
- center the portal for `top` and `bottom` positions on mobile
- style loading and icon only cards
- document how to enable new states with a loading boolean and bottom positioning
- update reducer so changing state activates the channel
- test loading spinner rendering and portal positioning

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6848041659a48329a2e035b2fcbac923