### PR TITLE
Extend overlay state options

### DIFF
--- a/src/components/state/hooks/useAggregator.ts
+++ b/src/components/state/hooks/useAggregator.ts
@@ -77,7 +77,8 @@ export default function useAggregator() {
     // ----- CHANNEL STATE -----
 
     /**
-     * Updates a channel's overlay state (e.g., 'collapsed', 'expanded', 'alert').
+     * Updates a channel's overlay state (e.g., 'collapsed', 'expanded', 'alert',
+     * 'split', 'bubble').
      * @param channelId Channel to update.
      * @param newState The new overlay state.
      */

--- a/src/components/state/reducers/channelReducer.ts
+++ b/src/components/state/reducers/channelReducer.ts
@@ -55,7 +55,7 @@ export function channelReducer(channel: Channel, action: OverlayAggregatorAction
         case 'UPDATE_CHANNEL_STATE': {
             if (action.payload.channelId !== channel.channelId) return channel;
 
-            // All valid overlay states are passed directly.
+            // All valid overlay states, including 'split' and 'bubble', are passed directly.
             const { newState } = action.payload;
 
             return {

--- a/src/components/state/types/channelTypes.ts
+++ b/src/components/state/types/channelTypes.ts
@@ -17,7 +17,9 @@ export type OverlayState =
     | 'alert'
     | 'swiping'
     | 'loading'
-    | 'icon';
+    | 'icon'
+    | 'split'
+    | 'bubble';
 
 /**
  * Channel represents a distinct data stream in the overlay system

--- a/src/components/state/types/overlayAggregatorActions.ts
+++ b/src/components/state/types/overlayAggregatorActions.ts
@@ -42,7 +42,7 @@ export type OverlayAggregatorAction =
     /**
      * Update the overlay state of a channel.
      * Supported states: 'hidden', 'collapsed', 'expanded', 'alert',
-     * 'swiping', 'loading', and 'icon'.
+     * 'swiping', 'loading', 'icon', 'split', and 'bubble'.
      */
     | {
           type: 'UPDATE_CHANNEL_STATE';


### PR DESCRIPTION
## Summary
- support `split` and `bubble` overlay states
- document new states in action comments and hook helpers
- mention new states in reducer comment

## Testing
- `npm test` *(fails: AggregatorProvider.debug.test.tsx and OverlayStates.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68496845d3f08329b675be57485adeac