### PR TITLE
Add bubbleIcon support to OverlayCard

### DIFF
--- a/example/src/pages/APIReference.tsx
+++ b/example/src/pages/APIReference.tsx
@@ -168,6 +168,13 @@ registerChannel('notifications', 1);`,
         since: 'v0.1.0'
       },
       {
+        name: 'bubbleIcon',
+        type: 'ReactNode',
+        description: 'Icon shown when the card is minimized to a bubble',
+        example: `bubbleIcon: <MessageCircle />`,
+        since: 'v0.4.0'
+      },
+      {
         name: 'autoDismiss',
         type: 'boolean',
         description: 'Whether the card should auto-dismiss',

--- a/src/components/core/card/OverlayCard.tsx
+++ b/src/components/core/card/OverlayCard.tsx
@@ -31,6 +31,7 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
     const isExpanded = channel.state === 'expanded';
     const isLoading = channel.state === 'loading';
     const isIconOnly = channel.state === 'icon';
+    const isBubble = channel.state === 'bubble';
     const isHidden = channel.state === 'hidden';
 
     // 🔹 Toggle expand/collapse on click
@@ -39,25 +40,25 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
             swipeTriggered.current = false;
             return;
         }
-        if (isLoading || isIconOnly || isHidden) return;
+        if (isLoading || isIconOnly || isBubble || isHidden) return;
         updateChannelState(channelId, isExpanded ? 'collapsed' : 'expanded');
-    }, [channelId, isExpanded, updateChannelState, isLoading, isIconOnly, isHidden]);
+    }, [channelId, isExpanded, updateChannelState, isLoading, isIconOnly, isBubble, isHidden]);
 
     const handleTouchStart = (e: React.TouchEvent) => {
-        if (isLoading || isIconOnly || isHidden) return;
+        if (isLoading || isIconOnly || isBubble || isHidden) return;
         touchStartX.current = e.touches[0].clientX;
         touchDeltaX.current = 0;
     };
 
     const handleTouchMove = (e: React.TouchEvent) => {
-        if (isLoading || isIconOnly || isHidden) return;
+        if (isLoading || isIconOnly || isBubble || isHidden) return;
         if (touchStartX.current !== null) {
             touchDeltaX.current = e.touches[0].clientX - touchStartX.current;
         }
     };
 
     const handleTouchEnd = () => {
-        if (isLoading || isIconOnly || isHidden) return;
+        if (isLoading || isIconOnly || isBubble || isHidden) return;
         if (touchStartX.current === null) return;
         
         const deltaX = touchDeltaX.current;
@@ -97,6 +98,8 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
         ? 'overlay-card--loading'
         : isIconOnly
         ? 'overlay-card--icon'
+        : isBubble
+        ? 'overlay-card--bubble'
         : isExpanded
         ? 'overlay-card--expanded'
         : 'overlay-card--collapsed';
@@ -136,8 +139,15 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
                 </div>
             )}
 
+            {/* 🔹 Bubble State */}
+            {isBubble && (card?.bubbleIcon || card?.icon) && (
+                <div className="overlay-card-bubble-icon" aria-hidden="true">
+                    {card.bubbleIcon || card.icon}
+                </div>
+            )}
+
             {/* 🔹 Normal Content */}
-            {!isLoading && !isIconOnly && !isHidden && card && (
+            {!isLoading && !isIconOnly && !isBubble && !isHidden && card && (
                 <>
                     {card.icon && (
                         <div className="overlay-card-icon\" aria-hidden="true">

--- a/src/components/state/types/overlayCardTypes.ts
+++ b/src/components/state/types/overlayCardTypes.ts
@@ -45,6 +45,11 @@ export interface OverlayCard {
     icon?: ReactNode;
 
     /**
+     * Optional icon used when the channel displays the card as a bubble.
+     */
+    bubbleIcon?: ReactNode;
+
+    /**
      * Future expansion: place icons, images, or other metadata here.
      */
     // iconUrl?: string;

--- a/tests/AggregatorProvider.debug.test.tsx
+++ b/tests/AggregatorProvider.debug.test.tsx
@@ -22,7 +22,8 @@ describe('AggregatorProvider debug logging', () => {
             </AggregatorProvider>
         );
         expect(groupSpy).toHaveBeenCalled();
-        expect(logSpy).toHaveBeenCalledTimes(3);
+        // Updated debug logging includes auto-dismiss setup messages
+        expect(logSpy).toHaveBeenCalledTimes(5);
         logSpy.mockRestore();
         groupSpy.mockRestore();
     });

--- a/tests/OverlayStates.test.tsx
+++ b/tests/OverlayStates.test.tsx
@@ -48,29 +48,29 @@ describe('overlay additional states', () => {
 
     it('applies sticky class on top', async () => {
         render(
-            <AggregatorProvider sticky position="top">
+            <AggregatorProvider fixedToViewport position="top">
                 <PositionSetup />
             </AggregatorProvider>
         );
         await waitFor(() => {
-            const el = document.querySelector('.overlay-portal.overlay-portal--sticky');
+            const el = document.querySelector('.overlay-portal.overlay-portal--fixed');
             expect(el).toBeTruthy();
         });
-        const portal = document.querySelector('.overlay-portal.overlay-portal--sticky');
+        const portal = document.querySelector('.overlay-portal.overlay-portal--fixed');
         expect(portal?.classList.contains('overlay-portal--top')).toBe(true);
     });
 
     it('applies sticky class on bottom', async () => {
         render(
-            <AggregatorProvider sticky position="bottom">
+            <AggregatorProvider fixedToViewport position="bottom">
                 <PositionSetup />
             </AggregatorProvider>
         );
         await waitFor(() => {
-            const el = document.querySelector('.overlay-portal.overlay-portal--sticky');
+            const el = document.querySelector('.overlay-portal.overlay-portal--fixed');
             expect(el).toBeTruthy();
         });
-        const portal = document.querySelector('.overlay-portal.overlay-portal--sticky');
+        const portal = document.querySelector('.overlay-portal.overlay-portal--fixed');
         expect(portal?.classList.contains('overlay-portal--bottom')).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- extend `OverlayCard` with optional `bubbleIcon`
- show bubble icon in `OverlayCard` when channel is in `bubble` state
- document new `bubbleIcon` field in API reference
- update tests for new debug logs and sticky prop rename

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68496e704bc483299e8a82512006bb09