### PR TITLE
Implement split overlay layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ The `example` folder doubles as the documentation site. After running the steps 
 
 Overlay updates are announced to assistive technologies using a polite live region. Overlay cards are focusable and respond to **Enter** or **Space** so keyboard users can toggle or dismiss them.
 
+## Running Tests
+
+Install dependencies and execute the test suite with:
+
+```bash
+npm install
+npm test
+```
+
+The `test` script runs `vitest` in single-run mode so it exits after completing all tests.
+
 ## Roadmap
 
 Upcoming development plans are tracked in [ROADMAP.md](ROADMAP.md). Highlights include:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "types": "dist/index.d.ts",
     "scripts": {
         "build": "rollup -c",
-        "test": "vitest",
+        "test": "vitest run",
         "dev": "npm run build && cd example && npm install && npm run dev"
     },
     "keywords": [],

--- a/src/components/core/card/OverlayCard.tsx
+++ b/src/components/core/card/OverlayCard.tsx
@@ -32,6 +32,7 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
     const isLoading = channel.state === 'loading';
     const isIconOnly = channel.state === 'icon';
     const isBubble = channel.state === 'bubble';
+    const isSplit = channel.state === 'split' || isLoading;
     const isHidden = channel.state === 'hidden';
 
     // 🔹 Toggle expand/collapse on click
@@ -103,10 +104,11 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
         : isExpanded
         ? 'overlay-card--expanded'
         : 'overlay-card--collapsed';
+    const splitClass = isSplit ? 'overlay-card--split' : '';
 
     return (
         <div
-            className={`overlay-card ${stateClass} ${directionClass}`}
+            className={`overlay-card ${stateClass} ${splitClass} ${directionClass}`}
             onClick={handleToggle}
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
@@ -122,49 +124,95 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
                 }
             }}
         >
-            {/* 🔹 Loading State */}
-            {isLoading && (
+
+            {isSplit ? (
                 <>
-                    <LoadingIndicator />
-                    {card?.title && (
-                        <span className="overlay-card-title">{card.title}</span>
+                    <div className="overlay-card-split-main">
+                        {isLoading ? (
+                            <>
+                                <LoadingIndicator />
+                                {card?.title && (
+                                    <span className="overlay-card-title">{card.title}</span>
+                                )}
+                            </>
+                        ) : (
+                            !isHidden && card && (
+                                <>
+                                    {card.icon && (
+                                        <div className="overlay-card-icon" aria-hidden="true">
+                                            {card.icon}
+                                        </div>
+                                    )}
+                                    <div className="overlay-card-content">
+                                        {card.title && (
+                                            <h3 className="overlay-card-title">{card.title}</h3>
+                                        )}
+                                        <p className="overlay-card-body">{card.content}</p>
+                                    </div>
+                                </>
+                            )
+                        )}
+                    </div>
+                    {(card?.bubbleIcon || card?.icon) && (
+                        <div
+                            className="overlay-card-split-bubble"
+                            role="button"
+                            aria-label={card?.title ? `Show ${card.title}` : 'Show overlay'}
+                            aria-haspopup="true"
+                        >
+                            {card.bubbleIcon || card.icon}
+                        </div>
                     )}
                 </>
-            )}
-
-            {/* 🔹 Icon Only State */}
-            {isIconOnly && card?.icon && (
-                <div className="overlay-card-icon" aria-hidden="true">
-                    {card.icon}
-                </div>
-            )}
-
-            {/* 🔹 Bubble State */}
-            {isBubble && (card?.bubbleIcon || card?.icon) && (
-                <div className="overlay-card-bubble-icon" aria-hidden="true">
-                    {card.bubbleIcon || card.icon}
-                </div>
-            )}
-
-            {/* 🔹 Normal Content */}
-            {!isLoading && !isIconOnly && !isBubble && !isHidden && card && (
+            ) : (
                 <>
-                    {card.icon && (
-                        <div className="overlay-card-icon\" aria-hidden="true">
+                    {/* 🔹 Loading State */}
+                    {isLoading && (
+                        <>
+                            <LoadingIndicator />
+                            {card?.title && (
+                                <span className="overlay-card-title">{card.title}</span>
+                            )}
+                        </>
+                    )}
+
+                    {/* 🔹 Icon Only State */}
+                    {isIconOnly && card?.icon && (
+                        <div className="overlay-card-icon" aria-hidden="true">
                             {card.icon}
                         </div>
                     )}
-                    <div className="overlay-card-content">
-                        {card.title && (
-                            <h3 className="overlay-card-title">{card.title}</h3>
-                        )}
-                        <p className="overlay-card-body">
-                            {card.content}
-                        </p>
-                    </div>
+
+                    {/* 🔹 Bubble State */}
+                    {isBubble && (card?.bubbleIcon || card?.icon) && (
+                        <div
+                            className="overlay-card-bubble-icon"
+                            role="button"
+                            aria-label={card?.title ? `Show ${card.title}` : 'Show overlay'}
+                            aria-haspopup="true"
+                        >
+                            {card.bubbleIcon || card.icon}
+                        </div>
+                    )}
+
+                    {/* 🔹 Normal Content */}
+                    {!isLoading && !isIconOnly && !isBubble && !isHidden && card && (
+                        <>
+                            {card.icon && (
+                                <div className="overlay-card-icon" aria-hidden="true">
+                                    {card.icon}
+                                </div>
+                            )}
+                            <div className="overlay-card-content">
+                                {card.title && (
+                                    <h3 className="overlay-card-title">{card.title}</h3>
+                                )}
+                                <p className="overlay-card-body">{card.content}</p>
+                            </div>
+                        </>
+                    )}
                 </>
             )}
-
             {/* 🔹 Actions (only in expanded mode) */}
             {isExpanded && (
                 <div className="overlay-card-actions">

--- a/src/components/style/components/overlay-card.css
+++ b/src/components/style/components/overlay-card.css
@@ -296,3 +296,49 @@
     backface-visibility: hidden;
     perspective: 1000px;
 }
+/* 🔹 Bubble Only State */
+.overlay-styled .overlay-card--bubble {
+    width: var(--overlay-collapsed-height);
+    height: var(--overlay-collapsed-height);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--overlay-padding-sm);
+}
+
+.overlay-styled .overlay-card-bubble-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+}
+
+/* 🔹 Split Layout */
+.overlay-styled .overlay-card--split {
+    display: flex;
+    align-items: center;
+    gap: var(--overlay-gap-sm);
+}
+
+.overlay-styled .overlay-card-split-main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--overlay-gap-sm);
+}
+
+.overlay-styled .overlay-card-split-bubble {
+    width: var(--overlay-collapsed-height);
+    height: var(--overlay-collapsed-height);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform var(--di-duration-normal) var(--di-spring-timing);
+}
+
+.overlay-styled .overlay-card--split:hover .overlay-card-split-bubble {
+    transform: scale(0);
+}


### PR DESCRIPTION
## Summary
- enable `split` and `bubble` display states in OverlayCard
- default loading state to split layout
- style bubble-only and split layouts
- run Vitest tests in single-run mode and document how to run them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68497214c4f08329a4380cd8b43252dd