### PR TITLE
Implement configurable default bubble icons

### DIFF
--- a/src/components/core/card/OverlayCard.tsx
+++ b/src/components/core/card/OverlayCard.tsx
@@ -15,6 +15,7 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
         removeCard,
         swipeNextCard,
         swipePrevCard,
+        config,
     } = useAggregator();
 
     const touchStartX = useRef<number | null>(null);
@@ -28,12 +29,22 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
         return null;
     }
 
+    const { splitLoading, defaultBubbleIcons } = config;
+
     const isExpanded = channel.state === 'expanded';
     const isLoading = channel.state === 'loading';
     const isIconOnly = channel.state === 'icon';
     const isBubble = channel.state === 'bubble';
-    const isSplit = channel.state === 'split' || isLoading;
+    const isSplit = channel.state === 'split' || (isLoading && splitLoading);
     const isHidden = channel.state === 'hidden';
+    const bubbleIconNode =
+        card?.bubbleIcon ??
+        card?.icon ??
+        (isLoading
+            ? defaultBubbleIcons.loading
+            : channel.state === 'alert'
+            ? defaultBubbleIcons.alert
+            : defaultBubbleIcons.message);
 
     // 🔹 Toggle expand/collapse on click
     const handleToggle = useCallback(() => {
@@ -153,16 +164,14 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
                             )
                         )}
                     </div>
-                    {(card?.bubbleIcon || card?.icon) && (
-                        <div
-                            className="overlay-card-split-bubble"
-                            role="button"
-                            aria-label={card?.title ? `Show ${card.title}` : 'Show overlay'}
-                            aria-haspopup="true"
-                        >
-                            {card.bubbleIcon || card.icon}
-                        </div>
-                    )}
+                    <div
+                        className="overlay-card-split-bubble"
+                        role="button"
+                        aria-label={card?.title ? `Show ${card.title}` : 'Show overlay'}
+                        aria-haspopup="true"
+                    >
+                        {bubbleIconNode}
+                    </div>
                 </>
             ) : (
                 <>
@@ -184,14 +193,14 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
                     )}
 
                     {/* 🔹 Bubble State */}
-                    {isBubble && (card?.bubbleIcon || card?.icon) && (
+                    {isBubble && (
                         <div
                             className="overlay-card-bubble-icon"
                             role="button"
                             aria-label={card?.title ? `Show ${card.title}` : 'Show overlay'}
                             aria-haspopup="true"
                         >
-                            {card.bubbleIcon || card.icon}
+                            {bubbleIconNode}
                         </div>
                     )}
 

--- a/src/components/core/utils/defaultIcons.tsx
+++ b/src/components/core/utils/defaultIcons.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export const messageIcon = (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M2 3a1 1 0 011-1h18a1 1 0 011 1v12a1 1 0 01-1 1H6l-4 4V3z" />
+    </svg>
+);
+
+export const spinnerIcon = (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 2a10 10 0 100 20 10 10 0 100-20zm0 2a8 8 0 110 16 8 8 0 010-16z" opacity="0.25" />
+        <path d="M12 2a10 10 0 0110 10h-3a7 7 0 00-7-7V2z" />
+    </svg>
+);
+
+export const alertIcon = (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path fillRule="evenodd" d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z" clipRule="evenodd" />
+    </svg>
+);

--- a/src/components/state/context/aggregatorContext.ts
+++ b/src/components/state/context/aggregatorContext.ts
@@ -5,12 +5,20 @@
  * Other files, like aggregatorProvider.ts, will set its value.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { OverlayAggregatorState, OverlayAggregatorAction } from '../types';
 
 export interface AggregatorContextValue {
     state: OverlayAggregatorState;
     dispatch: React.Dispatch<OverlayAggregatorAction>;
+    config: {
+        splitLoading: boolean;
+        defaultBubbleIcons: {
+            message: ReactNode;
+            loading: ReactNode;
+            alert: ReactNode;
+        };
+    };
 }
 
 // Create the context but provide an undefined default, so we can

--- a/src/components/state/context/aggregatorProvider.tsx
+++ b/src/components/state/context/aggregatorProvider.tsx
@@ -5,11 +5,13 @@ import React, {
     useRef,
     useCallback,
     PropsWithChildren,
+    ReactNode,
 } from 'react';
 import { aggregatorReducer } from '../reducers/aggregatorReducer';
 import { OverlayAggregatorState, OverlayAggregatorAction } from '../types';
 import { AggregatorContext } from './aggregatorContext';
 import { OverlayPortal } from '../../core/portal';
+import { messageIcon, spinnerIcon, alertIcon } from '../../core/utils/defaultIcons';
 import '../../style/index.css';
 
 // Possible concurrency modes
@@ -58,6 +60,21 @@ export interface AggregatorProviderConfig {
         | 'top-right'
         | 'bottom-left'
         | 'bottom-right';
+
+    /**
+     * When true, the loading state uses the split layout.
+     * Defaults to true.
+     */
+    splitLoading?: boolean;
+
+    /**
+     * Icons used when a bubble icon isn't supplied.
+     */
+    defaultBubbleIcons?: {
+        message: ReactNode;
+        loading: ReactNode;
+        alert: ReactNode;
+    };
 }
 
 export interface AggregatorProviderProps extends PropsWithChildren<AggregatorProviderConfig> {}
@@ -88,6 +105,12 @@ export default function AggregatorProvider({
     unstyled = false,
     fixedToViewport = true,
     position = 'top',
+    splitLoading = true,
+    defaultBubbleIcons = {
+        message: messageIcon,
+        loading: spinnerIcon,
+        alert: alertIcon,
+    },
 }: AggregatorProviderProps) {
     const [state, baseDispatch] = useReducer(aggregatorReducer, initialAggregatorState);
 
@@ -195,8 +218,12 @@ export default function AggregatorProvider({
 
     // Memoize the context value so we don't cause re-renders beyond the aggregator state changes
     const contextValue = useMemo(() => {
-        return { state, dispatch };
-    }, [state, dispatch]);
+        return {
+            state,
+            dispatch,
+            config: { splitLoading, defaultBubbleIcons },
+        };
+    }, [state, dispatch, splitLoading, defaultBubbleIcons]);
 
     return (
         <AggregatorContext.Provider value={contextValue}>

--- a/src/components/state/hooks/useAggregator.ts
+++ b/src/components/state/hooks/useAggregator.ts
@@ -35,7 +35,7 @@ export default function useAggregator() {
         throw new Error('useAggregator must be used within an AggregatorProvider');
     }
 
-    const { state, dispatch } = context;
+    const { state, dispatch, config } = context;
 
     // ----- CHANNEL LIFECYCLE -----
 
@@ -217,5 +217,6 @@ export default function useAggregator() {
         getChannel,
         getActiveChannel,
         getActiveCard,
+        config,
     };
 }

--- a/tests/OverlayCard.mobile.test.tsx
+++ b/tests/OverlayCard.mobile.test.tsx
@@ -5,13 +5,28 @@ import { aggregatorReducer } from '../src/components/state/reducers/aggregatorRe
 import { AggregatorContext } from '../src/components/state/context/aggregatorContext';
 import useAggregator from '../src/components/state/hooks/useAggregator';
 import { OverlayCard as OverlayCardComponent } from '../src/components/core/card/OverlayCard';
+import { messageIcon, spinnerIcon, alertIcon } from '../src/components/core/utils/defaultIcons';
 
 function TestProvider({ children }: { children: React.ReactNode }) {
     const [state, dispatch] = useReducer(aggregatorReducer, {
         channels: {},
         activeChannelId: null,
     });
-    const value = useMemo(() => ({ state, dispatch }), [state, dispatch]);
+    const value = useMemo(
+        () => ({
+            state,
+            dispatch,
+            config: {
+                splitLoading: true,
+                defaultBubbleIcons: {
+                    message: messageIcon,
+                    loading: spinnerIcon,
+                    alert: alertIcon,
+                },
+            },
+        }),
+        [state, dispatch]
+    );
     return (
         <AggregatorContext.Provider value={value}>{children}</AggregatorContext.Provider>
     );


### PR DESCRIPTION
## Summary
- add built‑in message, spinner and alert icons
- expose `splitLoading` and `defaultBubbleIcons` via `AggregatorProvider`
- surface config from context through `useAggregator`
- display fallback bubble icons in `OverlayCard`
- update tests for new context shape

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497c2734a0832997362e799534cea0