### PR TITLE
Handle split/bubble states in OverlayPortal

### DIFF
--- a/src/components/core/portal/OverlayPortal.tsx
+++ b/src/components/core/portal/OverlayPortal.tsx
@@ -44,10 +44,13 @@ export function OverlayPortal({
 
         const activeCard = getActiveCard(activeChannel.channelId);
         
-        // Show overlay if there's a card OR if channel is in loading/icon state
-        const shouldShow = activeCard || 
-                          activeChannel.state === 'loading' || 
-                          activeChannel.state === 'icon';
+        // Show overlay if there's a card OR if channel is in loading/icon/split/bubble state
+        const shouldShow =
+            activeCard ||
+            activeChannel.state === 'loading' ||
+            activeChannel.state === 'icon' ||
+            activeChannel.state === 'split' ||
+            activeChannel.state === 'bubble';
         
         if (!shouldShow) return null;
 
@@ -71,7 +74,11 @@ export function OverlayPortal({
     // 🔹 MULTIPLE CONCURRENCY MODE: Display multiple active overlays
     const activeChannels = Object.values(state.channels).filter(
         (ch) =>
-            ch.cards.length > 0 || ch.state === 'loading' || ch.state === 'icon'
+            ch.cards.length > 0 ||
+            ch.state === 'loading' ||
+            ch.state === 'icon' ||
+            ch.state === 'split' ||
+            ch.state === 'bubble'
     );
     
     // Nothing to render if no channel currently holds cards
@@ -133,10 +140,13 @@ function DefaultOverlay({
     const channel = state.channels[channelId];
     if (!channel) return null;
 
-    // Show overlay if there's a card OR if channel is in loading/icon state
-    const shouldShow = card || 
-                      channel.state === 'loading' || 
-                      channel.state === 'icon';
+    // Show overlay if there's a card OR if channel is in loading/icon/split/bubble state
+    const shouldShow =
+        card ||
+        channel.state === 'loading' ||
+        channel.state === 'icon' ||
+        channel.state === 'split' ||
+        channel.state === 'bubble';
     
     if (!shouldShow) return null;
 


### PR DESCRIPTION
## Summary
- show overlays when state is `split` or `bubble`
- ensure multiple concurrency mode handles these states

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849825607648329a536e078f5e162d6