### PR TITLE
Add tests for split/bubble states

### DIFF
--- a/tests/OverlayCard.mobile.test.tsx
+++ b/tests/OverlayCard.mobile.test.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useReducer, useMemo } from 'react';
-import { render, fireEvent, screen } from '@testing-library/react/pure';
-import { describe, it, expect } from 'vitest';
+import { render, fireEvent, screen, cleanup } from '@testing-library/react/pure';
+import { describe, it, expect, afterEach } from 'vitest';
 import { aggregatorReducer } from '../src/components/state/reducers/aggregatorReducer';
 import { AggregatorContext } from '../src/components/state/context/aggregatorContext';
 import useAggregator from '../src/components/state/hooks/useAggregator';
 import { OverlayCard as OverlayCardComponent } from '../src/components/core/card/OverlayCard';
 import { messageIcon, spinnerIcon, alertIcon } from '../src/components/core/utils/defaultIcons';
+
+afterEach(() => {
+    cleanup();
+});
 
 function TestProvider({ children }: { children: React.ReactNode }) {
     const [state, dispatch] = useReducer(aggregatorReducer, {
@@ -53,7 +57,7 @@ describe('OverlayCard mobile swipes', () => {
                 <Setup />
             </TestProvider>
         );
-        const card = screen.getAllByRole('button')[0];
+        const card = screen.getByRole('button', { name: /Overlay Card/ });
         expect(card.textContent).toContain('A');
         fireEvent.touchStart(card, { touches: [{ clientX: 100 }] });
         fireEvent.touchMove(card, { touches: [{ clientX: 30 }] });
@@ -67,7 +71,7 @@ describe('OverlayCard mobile swipes', () => {
                 <Setup />
             </TestProvider>
         );
-        const card = screen.getAllByRole('button')[0];
+        const card = screen.getByRole('button', { name: /Overlay Card/ });
         // move to next first
         fireEvent.touchStart(card, { touches: [{ clientX: 100 }] });
         fireEvent.touchMove(card, { touches: [{ clientX: 30 }] });
@@ -78,5 +82,78 @@ describe('OverlayCard mobile swipes', () => {
         fireEvent.touchMove(card, { touches: [{ clientX: 100 }] });
         fireEvent.touchEnd(card, { changedTouches: [{ clientX: 100 }] });
         expect(card.textContent).toContain('A');
+    });
+
+    function SplitSetup() {
+        const { registerChannel, addCard, updateChannelState, state } =
+            useAggregator();
+        useEffect(() => {
+            registerChannel('ch', 1);
+            addCard('ch', { id: 'a', title: 'A', content: 'A' });
+            addCard('ch', { id: 'b', title: 'B', content: 'B' });
+            updateChannelState('ch', 'split');
+        }, [registerChannel, addCard, updateChannelState]);
+
+        const channel = state.channels['ch'];
+        if (!channel) return null;
+        const card = channel.cards[channel.activeCardIndex];
+        return <OverlayCardComponent channelId="ch" card={card} />;
+    }
+
+    function BubbleSetup({ indexRef }: { indexRef: { current: number } }) {
+        const { registerChannel, addCard, updateChannelState, state } =
+            useAggregator();
+        useEffect(() => {
+            registerChannel('ch', 1);
+            addCard('ch', { id: 'a', title: 'A', content: 'A' });
+            addCard('ch', { id: 'b', title: 'B', content: 'B' });
+            updateChannelState('ch', 'bubble');
+        }, [registerChannel, addCard, updateChannelState]);
+
+        useEffect(() => {
+            const idx = state.channels['ch']?.activeCardIndex ?? 0;
+            indexRef.current = idx;
+        }, [state]);
+
+        const channel = state.channels['ch'];
+        if (!channel) return null;
+        const card = channel.cards[channel.activeCardIndex];
+        return (
+            <>
+                <OverlayCardComponent channelId="ch" card={card} />
+            </>
+        );
+    }
+
+    it('allows swiping in split state', () => {
+        render(
+            <TestProvider>
+                <SplitSetup />
+            </TestProvider>
+        );
+        const card = screen.getByRole('button', { name: /Overlay Card/ });
+        expect(card.classList.contains('overlay-card--split')).toBe(true);
+        expect(card.textContent).toContain('A');
+        fireEvent.touchStart(card, { touches: [{ clientX: 100 }] });
+        fireEvent.touchMove(card, { touches: [{ clientX: 30 }] });
+        fireEvent.touchEnd(card, { changedTouches: [{ clientX: 30 }] });
+        expect(card.textContent).toContain('B');
+        const bubble = screen.getByLabelText(/Show/);
+        expect(bubble).toBeTruthy();
+    });
+
+    it('ignores swipes in bubble state', () => {
+        const indexRef = { current: 0 };
+        render(
+            <TestProvider>
+                <BubbleSetup indexRef={indexRef} />
+            </TestProvider>
+        );
+        const card = screen.getByRole('button', { name: /Overlay Card/ });
+        expect(card.classList.contains('overlay-card--bubble')).toBe(true);
+        fireEvent.touchStart(card, { touches: [{ clientX: 100 }] });
+        fireEvent.touchMove(card, { touches: [{ clientX: 30 }] });
+        fireEvent.touchEnd(card, { changedTouches: [{ clientX: 30 }] });
+        expect(indexRef.current).toBe(0);
     });
 });

--- a/tests/OverlayStates.test.tsx
+++ b/tests/OverlayStates.test.tsx
@@ -26,6 +26,26 @@ function PositionSetup() {
     return null;
 }
 
+function SplitStateSetup() {
+    const { registerChannel, addCard, updateChannelState } = useAggregator();
+    useEffect(() => {
+        registerChannel('split', 1);
+        addCard('split', { id: 'a', title: 'A', content: 'A' });
+        updateChannelState('split', 'split');
+    }, [registerChannel, addCard, updateChannelState]);
+    return null;
+}
+
+function BubbleStateSetup() {
+    const { registerChannel, addCard, updateChannelState } = useAggregator();
+    useEffect(() => {
+        registerChannel('bubble', 1);
+        addCard('bubble', { id: 'a', title: 'A', content: 'A' });
+        updateChannelState('bubble', 'bubble');
+    }, [registerChannel, addCard, updateChannelState]);
+    return null;
+}
+
 describe('overlay additional states', () => {
     it('renders spinner when loading', () => {
         render(
@@ -72,5 +92,29 @@ describe('overlay additional states', () => {
         });
         const portal = document.querySelector('.overlay-portal.overlay-portal--fixed');
         expect(portal?.classList.contains('overlay-portal--bottom')).toBe(true);
+    });
+
+    it('portal and card reflect split state', () => {
+        render(
+            <AggregatorProvider>
+                <SplitStateSetup />
+            </AggregatorProvider>
+        );
+        const portal = document.querySelector('.overlay-portal');
+        const card = document.querySelector('.overlay-card');
+        expect(portal?.getAttribute('data-state')).toBe('split');
+        expect(card?.classList.contains('overlay-card--split')).toBe(true);
+    });
+
+    it('portal and card reflect bubble state', () => {
+        render(
+            <AggregatorProvider>
+                <BubbleStateSetup />
+            </AggregatorProvider>
+        );
+        const portal = document.querySelector('.overlay-portal');
+        const card = document.querySelector('.overlay-card');
+        expect(portal?.getAttribute('data-state')).toBe('bubble');
+        expect(card?.classList.contains('overlay-card--bubble')).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- extend mobile swipe tests with split and bubble card states
- add portal class tests for split and bubble states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849837b28688329bce66ce8890c8d22