### PR TITLE
Add split loading docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ useEffect(() => {
 // later: setLoading(false); updateChannelState('playback', 'icon');
 ```
 
+### Split Loading & Bubble Icons
+
+Use the `splitLoading` prop to show the split layout while a channel is loading.
+Provide bubble icons globally through `defaultBubbleIcons` or per card via the
+`bubbleIcon` field.
+
+```tsx
+import { MessageCircle, Loader2, Bell, AlertCircle } from 'lucide-react';
+
+<Floatify
+  splitLoading
+  defaultBubbleIcons={{
+    message: <MessageCircle />,
+    loading: <Loader2 className="animate-spin" />,
+    alert: <AlertCircle />
+  }}
+>
+  {/* rest of your app */}
+</Floatify>
+
+addCard('updates', {
+  id: 'done',
+  title: 'Complete',
+  content: 'Process finished',
+  bubbleIcon: <Bell />
+});
+```
+
 ## Debug Mode
 
 Enable debug logging by passing the `debug` prop to `Floatify` or

--- a/example/src/pages/APIReference.tsx
+++ b/example/src/pages/APIReference.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Book, Code, Zap, Settings, Database } from 'lucide-react';
+import { Book, Code, Zap, Settings, Database, MessageCircle, Loader2, AlertCircle } from 'lucide-react';
 import APITopNavigation from '../components/APITopNavigation';
 import APISection from '../components/APISection';
 import CodeBlock from '../components/CodeBlock';
@@ -69,6 +69,21 @@ const apiSections: APISection[] = [
         description: 'Custom DOM element to render overlays into',
         example: `<Floatify portalRoot={document.getElementById('overlays')}>`,
         since: 'v0.1.0'
+      },
+      {
+        name: 'splitLoading',
+        type: 'boolean',
+        description: 'Use split layout while a channel is loading',
+        defaultValue: 'true',
+        example: `<Floatify splitLoading>`,
+        since: 'v0.4.0'
+      },
+      {
+        name: 'defaultBubbleIcons',
+        type: '{ message: ReactNode; loading: ReactNode; alert: ReactNode; }',
+        description: 'Icons used when a card does not specify a bubble icon',
+        example: `<Floatify defaultBubbleIcons={{ message: <MessageCircle />, loading: <Loader2 />, alert: <AlertCircle /> }}>`,
+        since: 'v0.4.0'
       }
     ]
   },

--- a/example/src/pages/Examples.tsx
+++ b/example/src/pages/Examples.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Copy, Play, RotateCcw, CheckCircle, AlertCircle, Info, Zap } from 'lucide-react';
+import { Copy, Play, RotateCcw, CheckCircle, AlertCircle, Info, Zap, Code } from 'lucide-react';
 import Demo from '../components/Demo';
 import Button from '../components/Button';
 import CodeBlock from '../components/CodeBlock';
@@ -81,7 +81,27 @@ const handleAsyncAction = async () => {
   concurrencyMode="single"    // single or multiple overlays
 >
   {/* Your app */}
-</Floatify>`
+</Floatify>`,
+
+  split: `import { MessageCircle, Loader2, Bell, AlertCircle } from 'lucide-react';
+
+<Floatify
+  splitLoading
+  defaultBubbleIcons={{
+    message: <MessageCircle />,
+    loading: <Loader2 className="animate-spin" />,
+    alert: <AlertCircle />
+  }}
+>
+  {/* app */}
+</Floatify>
+
+addCard('updates', {
+  id: 'done',
+  title: 'Complete',
+  content: 'Process finished',
+  bubbleIcon: <Bell />
+});`
 };
 
 export default function Examples({
@@ -110,6 +130,12 @@ export default function Examples({
       title: 'Positioning & Layout',
       description: 'Control overlay position and behavior',
       icon: <Zap size={16} />
+    },
+    {
+      key: 'split',
+      title: 'Split Loading & Bubbles',
+      description: 'Enable split layout and custom bubble icons',
+      icon: <Code size={16} />
     }
   ];
 
@@ -200,15 +226,23 @@ export default function Examples({
             <p>Notify users about system maintenance, new features, or important announcements.</p>
           </div>
           
-          <div className="use-case-card">
-            <div className="use-case-icon">
-              <RotateCcw size={24} />
+            <div className="use-case-card">
+              <div className="use-case-icon">
+                <RotateCcw size={24} />
+              </div>
+              <h3>Loading States</h3>
+              <p>Show progress for long-running operations with clear status updates.</p>
             </div>
-            <h3>Loading States</h3>
-            <p>Show progress for long-running operations with clear status updates.</p>
+
+            <div className="use-case-card">
+              <div className="use-case-icon">
+                <Code size={24} />
+              </div>
+              <h3>Split Layout & Bubbles</h3>
+              <p>Use split loading with custom bubble icons for minimized cards.</p>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
       {/* Best Practices */}
       <section className="best-practices">


### PR DESCRIPTION
## Summary
- document enabling `splitLoading` and customizing bubble icons in README
- show split loading and bubble icon usage in example app
- add `splitLoading` and `defaultBubbleIcons` to API reference

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684985118b7c83298ba863a4cc2e7161