### PR TITLE
Add bubble and split overlay styles

### DIFF
--- a/src/components/style/components/overlay-portal.css
+++ b/src/components/style/components/overlay-portal.css
@@ -68,6 +68,22 @@
     --di-scale-current: var(--di-scale-collapsed);
 }
 
+.overlay-styled .overlay-portal[data-state='bubble'] {
+    width: var(--overlay-collapsed-height);
+    height: var(--overlay-collapsed-height);
+    border-radius: 50%;
+    transform: scale(var(--di-scale-collapsed));
+    --di-scale-current: var(--di-scale-collapsed);
+}
+
+.overlay-styled .overlay-portal[data-state='split'] {
+    width: calc(var(--overlay-collapsed-width) + var(--overlay-collapsed-height) + var(--overlay-gap-sm));
+    height: var(--overlay-collapsed-height);
+    border-radius: calc(var(--overlay-collapsed-height) / 2);
+    transform: scale(var(--di-scale-collapsed));
+    --di-scale-current: var(--di-scale-collapsed);
+}
+
 /* Hover & Press Effects with spring timing */
 .overlay-styled .overlay-portal:hover {
     transform: scale(calc(var(--di-scale-current, 1) * var(--di-hover-scale, 1.03)));


### PR DESCRIPTION
## Summary
- add new CSS rules for bubble and split overlay states in `overlay-portal.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849895f80b08329909a0480deb8b54d