### PR TITLE
Update overlay split width

### DIFF
--- a/src/components/style/components/overlay-card.css
+++ b/src/components/style/components/overlay-card.css
@@ -321,6 +321,7 @@
     display: flex;
     align-items: center;
     gap: var(--overlay-gap-sm);
+    width: calc(var(--overlay-collapsed-width) + var(--overlay-collapsed-height) + var(--overlay-gap-sm));
 }
 
 .overlay-styled .overlay-card-split-main {


### PR DESCRIPTION
## Summary
- ensure overlay-card split layout uses correct combined width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684989e470f08329b8c22612be3eba6b