### PR TITLE
Add width assertions for overlay states

### DIFF
--- a/tests/OverlayStates.test.tsx
+++ b/tests/OverlayStates.test.tsx
@@ -104,6 +104,8 @@ describe('overlay additional states', () => {
         const card = document.querySelector('.overlay-card');
         expect(portal?.getAttribute('data-state')).toBe('split');
         expect(card?.classList.contains('overlay-card--split')).toBe(true);
+        const style = getComputedStyle(portal as Element);
+        expect(style.width).toBe('');
     });
 
     it('portal and card reflect bubble state', () => {
@@ -116,5 +118,7 @@ describe('overlay additional states', () => {
         const card = document.querySelector('.overlay-card');
         expect(portal?.getAttribute('data-state')).toBe('bubble');
         expect(card?.classList.contains('overlay-card--bubble')).toBe(true);
+        const style = getComputedStyle(portal as Element);
+        expect(style.width).toBe('');
     });
 });


### PR DESCRIPTION
## Summary
- extend overlay state tests to assert computed width for split and bubble states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68498a62eab883299bec4451e43cba84