### PR TITLE
Add split bubble example page

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,6 +6,7 @@ import Home from './pages/Home'
 import Examples from './pages/Examples'
 import APIReference from './pages/APIReference'
 import Roadmap from './pages/Roadmap'
+import SplitBubbleExample from './pages/SplitBubbleExample'
 import { Position } from './types'
 
 // Centralized CSS imports
@@ -49,6 +50,7 @@ export default function App() {
               />
             }
           />
+          <Route path="/split-bubble" element={<SplitBubbleExample />} />
           <Route path="/api" element={<APIReference />} />
           <Route path="/roadmap" element={<Roadmap />} />
         </Routes>

--- a/example/src/components/Layout.tsx
+++ b/example/src/components/Layout.tsx
@@ -11,6 +11,7 @@ interface Props {
 const navigation = [
   { name: 'Overview', href: '/' },
   { name: 'Examples', href: '/examples' },
+  { name: 'Split Bubble', href: '/split-bubble' },
   { name: 'API Reference', href: '/api' },
   { name: 'Roadmap', href: '/roadmap' },
 ];

--- a/example/src/pages/SplitBubbleExample.tsx
+++ b/example/src/pages/SplitBubbleExample.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import SplitBubbleDemo from '../components/SplitBubbleDemo'
+
+export default function SplitBubbleExample() {
+  return (
+    <div className="split-bubble-example">
+      <h1>Split Bubble Demo</h1>
+      <SplitBubbleDemo />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create SplitBubbleExample page
- add route to SplitBubbleExample
- expose split bubble in navigation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498f33c90c83298b3befc2e2622840