### PR TITLE
Remove deprecated icon state

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,9 @@ On mobile devices only `top` or `bottom` positions are recommended.
 </Floatify>
 ```
 
-### Loading & Icon States
+### Loading & Bubble State
 
-Set a channel to `'loading'` to show a spinner or `'icon'` to display just the icon.
-A typical pattern is to drive this from a loading boolean:
+Set a channel to `'loading'` to show a spinner and switch to `'bubble'` when only an icon should remain. A typical pattern is to drive this from a loading boolean:
 
 ```tsx
 const { registerChannel, updateChannelState } = useAggregator();
@@ -104,7 +103,7 @@ useEffect(() => {
   updateChannelState('playback', loading ? 'loading' : 'collapsed');
 }, [loading, updateChannelState]);
 
-// later: setLoading(false); updateChannelState('playback', 'icon');
+// later: setLoading(false); updateChannelState('playback', 'bubble');
 ```
 
 ### Split Loading & Bubble Icons

--- a/example/src/components/Demo.tsx
+++ b/example/src/components/Demo.tsx
@@ -39,7 +39,7 @@ export default function Demo({
       id,
       title: 'Loading…',
       content: 'Please wait',
-      icon: <Loader2 className="spin" />,
+      bubbleIcon: <Loader2 className="spin" />,
       autoDismiss: false // Don't auto-dismiss loading states
     })
 
@@ -49,7 +49,7 @@ export default function Demo({
         id: `${id}-done`,
         title: 'Complete',
         content: 'Operation successful',
-        icon: <CheckCircle />,
+        bubbleIcon: <CheckCircle />,
         autoDismiss: true,
         autoDismissDuration: 2000 // Shorter duration for success messages
       })

--- a/example/src/components/SplitBubbleDemo.tsx
+++ b/example/src/components/SplitBubbleDemo.tsx
@@ -15,7 +15,6 @@ export default function SplitBubbleDemo() {
       id: Date.now().toString(),
       title: 'Processing...',
       content: 'Demonstrating the split layout during loading.',
-      icon: <Loader2 className="spin" />,
       bubbleIcon: <Bell />
     })
     updateChannelState('demo-split', 'split')
@@ -26,7 +25,6 @@ export default function SplitBubbleDemo() {
       id: Date.now().toString(),
       title: 'New Message',
       content: 'This card is displayed as a bubble.',
-      icon: <AlertCircle />,
       bubbleIcon: <MessageCircle />
     })
     updateChannelState('demo-split', 'bubble')

--- a/example/src/pages/APIReference.tsx
+++ b/example/src/pages/APIReference.tsx
@@ -176,13 +176,6 @@ registerChannel('notifications', 1);`,
         since: 'v0.1.0'
       },
       {
-        name: 'icon',
-        type: 'ReactNode',
-        description: 'Optional icon element to display',
-        example: `icon: <CheckCircle />`,
-        since: 'v0.1.0'
-      },
-      {
         name: 'bubbleIcon',
         type: 'ReactNode',
         description: 'Icon shown when the card is minimized to a bubble',
@@ -235,12 +228,6 @@ registerChannel('notifications', 1);`,
         name: 'loading',
         type: 'OverlayState',
         description: 'Channel shows a loading spinner',
-        since: 'v0.2.0'
-      },
-      {
-        name: 'icon',
-        type: 'OverlayState',
-        description: 'Channel shows only an icon',
         since: 'v0.2.0'
       },
       {

--- a/src/components/core/card/OverlayCard.tsx
+++ b/src/components/core/card/OverlayCard.tsx
@@ -33,13 +33,11 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
 
     const isExpanded = channel.state === 'expanded';
     const isLoading = channel.state === 'loading';
-    const isIconOnly = channel.state === 'icon';
     const isBubble = channel.state === 'bubble';
     const isSplit = channel.state === 'split' || (isLoading && splitLoading);
     const isHidden = channel.state === 'hidden';
     const bubbleIconNode =
         card?.bubbleIcon ??
-        card?.icon ??
         (isLoading
             ? defaultBubbleIcons.loading
             : channel.state === 'alert'
@@ -52,25 +50,25 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
             swipeTriggered.current = false;
             return;
         }
-        if (isLoading || isIconOnly || isBubble || isHidden) return;
+        if (isLoading || isBubble || isHidden) return;
         updateChannelState(channelId, isExpanded ? 'collapsed' : 'expanded');
-    }, [channelId, isExpanded, updateChannelState, isLoading, isIconOnly, isBubble, isHidden]);
+    }, [channelId, isExpanded, updateChannelState, isLoading, isBubble, isHidden]);
 
     const handleTouchStart = (e: React.TouchEvent) => {
-        if (isLoading || isIconOnly || isBubble || isHidden) return;
+        if (isLoading || isBubble || isHidden) return;
         touchStartX.current = e.touches[0].clientX;
         touchDeltaX.current = 0;
     };
 
     const handleTouchMove = (e: React.TouchEvent) => {
-        if (isLoading || isIconOnly || isBubble || isHidden) return;
+        if (isLoading || isBubble || isHidden) return;
         if (touchStartX.current !== null) {
             touchDeltaX.current = e.touches[0].clientX - touchStartX.current;
         }
     };
 
     const handleTouchEnd = () => {
-        if (isLoading || isIconOnly || isBubble || isHidden) return;
+        if (isLoading || isBubble || isHidden) return;
         if (touchStartX.current === null) return;
         
         const deltaX = touchDeltaX.current;
@@ -108,8 +106,6 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
         ? 'overlay-card--hidden'
         : isLoading
         ? 'overlay-card--loading'
-        : isIconOnly
-        ? 'overlay-card--icon'
         : isBubble
         ? 'overlay-card--bubble'
         : isExpanded
@@ -149,11 +145,6 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
                         ) : (
                             !isHidden && card && (
                                 <>
-                                    {card.icon && (
-                                        <div className="overlay-card-icon" aria-hidden="true">
-                                            {card.icon}
-                                        </div>
-                                    )}
                                     <div className="overlay-card-content">
                                         {card.title && (
                                             <h3 className="overlay-card-title">{card.title}</h3>
@@ -185,12 +176,6 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
                         </>
                     )}
 
-                    {/* 🔹 Icon Only State */}
-                    {isIconOnly && card?.icon && (
-                        <div className="overlay-card-icon" aria-hidden="true">
-                            {card.icon}
-                        </div>
-                    )}
 
                     {/* 🔹 Bubble State */}
                     {isBubble && (
@@ -205,13 +190,8 @@ export function OverlayCard({ channelId, card }: OverlayCardProps) {
                     )}
 
                     {/* 🔹 Normal Content */}
-                    {!isLoading && !isIconOnly && !isBubble && !isHidden && card && (
+                    {!isLoading && !isBubble && !isHidden && card && (
                         <>
-                            {card.icon && (
-                                <div className="overlay-card-icon" aria-hidden="true">
-                                    {card.icon}
-                                </div>
-                            )}
                             <div className="overlay-card-content">
                                 {card.title && (
                                     <h3 className="overlay-card-title">{card.title}</h3>

--- a/src/components/core/portal/OverlayPortal.tsx
+++ b/src/components/core/portal/OverlayPortal.tsx
@@ -44,11 +44,10 @@ export function OverlayPortal({
 
         const activeCard = getActiveCard(activeChannel.channelId);
         
-        // Show overlay if there's a card OR if channel is in loading/icon/split/bubble state
+        // Show overlay if there's a card or the channel is in a visible state
         const shouldShow =
             activeCard ||
             activeChannel.state === 'loading' ||
-            activeChannel.state === 'icon' ||
             activeChannel.state === 'split' ||
             activeChannel.state === 'bubble';
         
@@ -76,7 +75,6 @@ export function OverlayPortal({
         (ch) =>
             ch.cards.length > 0 ||
             ch.state === 'loading' ||
-            ch.state === 'icon' ||
             ch.state === 'split' ||
             ch.state === 'bubble'
     );
@@ -140,11 +138,10 @@ function DefaultOverlay({
     const channel = state.channels[channelId];
     if (!channel) return null;
 
-    // Show overlay if there's a card OR if channel is in loading/icon/split/bubble state
+    // Show overlay if there's a card or the channel is visible
     const shouldShow =
         card ||
         channel.state === 'loading' ||
-        channel.state === 'icon' ||
         channel.state === 'split' ||
         channel.state === 'bubble';
     

--- a/src/components/state/types/channelTypes.ts
+++ b/src/components/state/types/channelTypes.ts
@@ -17,7 +17,6 @@ export type OverlayState =
     | 'alert'
     | 'swiping'
     | 'loading'
-    | 'icon'
     | 'split'
     | 'bubble';
 

--- a/src/components/state/types/overlayAggregatorActions.ts
+++ b/src/components/state/types/overlayAggregatorActions.ts
@@ -42,7 +42,7 @@ export type OverlayAggregatorAction =
     /**
      * Update the overlay state of a channel.
      * Supported states: 'hidden', 'collapsed', 'expanded', 'alert',
-     * 'swiping', 'loading', 'icon', 'split', and 'bubble'.
+     * 'swiping', 'loading', 'split', and 'bubble'.
      */
     | {
           type: 'UPDATE_CHANNEL_STATE';

--- a/src/components/state/types/overlayCardTypes.ts
+++ b/src/components/state/types/overlayCardTypes.ts
@@ -40,11 +40,6 @@ export interface OverlayCard {
     timestamp?: number;
 
     /**
-     * Optional visual icon element to display with the card.
-     */
-    icon?: ReactNode;
-
-    /**
      * Optional icon used when the channel displays the card as a bubble.
      */
     bubbleIcon?: ReactNode;

--- a/src/components/style/components/overlay-card.css
+++ b/src/components/style/components/overlay-card.css
@@ -46,9 +46,8 @@
     pointer-events: auto;
 }
 
-/* 🔹 STATE: Icon Only (Loading/Minimal) */
-.overlay-styled .overlay-card--loading,
-.overlay-styled .overlay-card--icon {
+/* 🔹 STATE: Loading */
+.overlay-styled .overlay-card--loading {
     width: var(--overlay-collapsed-height);
     height: var(--overlay-collapsed-height);
     border-radius: 50%;
@@ -57,8 +56,7 @@
     align-items: center;
 }
 
-.overlay-styled .overlay-card--loading .overlay-card-content,
-.overlay-styled .overlay-card--icon .overlay-card-content {
+.overlay-styled .overlay-card--loading .overlay-card-content {
     display: none;
 }
 
@@ -145,8 +143,7 @@
     height: 20px;
 }
 
-.overlay-styled .overlay-card--loading .overlay-card-icon,
-.overlay-styled .overlay-card--icon .overlay-card-icon {
+.overlay-styled .overlay-card--loading .overlay-card-icon {
     width: 24px;
     height: 24px;
 }

--- a/src/components/style/components/overlay-portal.css
+++ b/src/components/style/components/overlay-portal.css
@@ -59,8 +59,7 @@
     border-radius: calc(var(--overlay-collapsed-height) / 2);
 }
 
-.overlay-styled .overlay-portal[data-state='loading'],
-.overlay-styled .overlay-portal[data-state='icon'] {
+.overlay-styled .overlay-portal[data-state='loading'] {
     width: var(--overlay-collapsed-height);
     height: var(--overlay-collapsed-height);
     border-radius: 50%;


### PR DESCRIPTION
## Summary
- drop `icon` state and icon field from overlay types
- remove icon-specific UI and CSS
- update portal logic for visible states
- document bubble state and bubbleIcon usage
- refresh example components for bubbleIcon

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499e1e46cc8329b4cb9a41dfec2797