### PR TITLE
Update overlay card hover styles

### DIFF
--- a/src/components/style/components/overlay-card.css
+++ b/src/components/style/components/overlay-card.css
@@ -333,6 +333,12 @@
     transition: all var(--di-duration-normal) var(--di-spring-timing);
 }
 
+/* Hover effect for split main */
+.overlay-styled .overlay-card-split-main:hover {
+    transform: scale(1.02);
+    box-shadow: var(--di-shadow-hover);
+}
+
 /* Split Bubble - Distinct separate element */
 .overlay-styled .overlay-card-split-bubble {
     width: var(--overlay-collapsed-height);
@@ -361,7 +367,6 @@
 /* Hover effect - merge back animation */
 .overlay-styled .overlay-card--split:hover {
     gap: 0; /* Close the gap */
-    transform: scale(1.02); /* Slight scale increase for feedback */
 }
 
 /* Main content expands to fill space */
@@ -373,9 +378,9 @@
 
 /* Bubble fades out and becomes non-interactive */
 .overlay-styled .overlay-card--split:hover .overlay-card-split-bubble {
-    opacity: 0;
+    opacity: 0.5;
     pointer-events: none;
-    transform: scale(0.8);
+    transform: scale(0.5);
 }
 
 /* =======================================================

--- a/src/components/style/themes/full-theme.css
+++ b/src/components/style/themes/full-theme.css
@@ -12,6 +12,7 @@
     --di-background-rgb: 28, 28, 30;
     --di-text: rgba(255, 255, 255, 0.98); /* Higher opacity for better readability */
     --di-shadow: 0 8px 32px rgba(0, 0, 0, 0.4); /* Stronger shadow */
+    --di-shadow-hover: 0 12px 32px rgba(0, 0, 0, 0.45);
     --di-focus-ring: rgba(255, 255, 255, 0.7);
 
     /* 🪟 Glass Effect - IMPROVED VISIBILITY */
@@ -49,6 +50,7 @@
     --di-background-rgb: 248, 248, 248;
     --di-text: rgba(28, 28, 30, 0.98); /* Higher contrast */
     --di-shadow: 0 8px 32px rgba(0, 0, 0, 0.25); /* Stronger shadow */
+    --di-shadow-hover: 0 12px 32px rgba(0, 0, 0, 0.3);
     --di-focus-ring: rgba(0, 0, 0, 0.3);
 
     /* 🪟 Glass effect adjustments */


### PR DESCRIPTION
## Summary
- tweak split hover effect for bubble
- add scale and hover shadow for split main
- add `--di-shadow-hover` theme variable and apply it

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849be48791c83299790fc87ee5225e1