### PR TITLE
Fix split card transitions

### DIFF
--- a/src/components/style/components/overlay-card.css
+++ b/src/components/style/components/overlay-card.css
@@ -330,7 +330,7 @@
     -webkit-backdrop-filter: blur(var(--di-glass-blur));
     
     height: var(--overlay-collapsed-height);
-    transition: all var(--di-duration-normal) var(--di-spring-timing);
+    transition: var(--di-duration-normal) var(--di-spring-timing);
 }
 
 /* Hover effect for split main */
@@ -356,7 +356,7 @@
     backdrop-filter: blur(var(--di-glass-blur));
     -webkit-backdrop-filter: blur(var(--di-glass-blur));
     
-    transition: all var(--di-duration-normal) var(--di-spring-timing);
+    transition: var(--di-duration-normal) var(--di-spring-timing);
     cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- ensure split card bubble and main have consistent transitions
- keep collapsed height stable on split card main

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849bf260a7c83298d8fa8c938f51f23