### PR TITLE
Update docs for bubbleIcon usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ On mobile devices only `top` or `bottom` positions are recommended.
 
 ### Loading & Bubble State
 
-Set a channel to `'loading'` to show a spinner and switch to `'bubble'` when only an icon should remain. A typical pattern is to drive this from a loading boolean:
+Set a channel to `'loading'` to show a spinner and switch to `'bubble'` once loading completes. A typical pattern is to drive this from a loading boolean:
 
 ```tsx
 const { registerChannel, updateChannelState } = useAggregator();

--- a/example/src/pages/Examples.tsx
+++ b/example/src/pages/Examples.tsx
@@ -49,7 +49,7 @@ const handleAsyncAction = async () => {
     id: loadingId,
     title: 'Processing...',
     content: 'Please wait while we process your request',
-    icon: <Loader2 className="animate-spin" />
+    bubbleIcon: <Loader2 className="animate-spin" />
   });
 
   try {
@@ -61,7 +61,7 @@ const handleAsyncAction = async () => {
       id: \`\${loadingId}-success\`,
       title: 'Complete!',
       content: 'Operation completed successfully',
-      icon: <CheckCircle />
+      bubbleIcon: <CheckCircle />
     });
   } catch (error) {
     // Show error state
@@ -70,7 +70,7 @@ const handleAsyncAction = async () => {
       id: \`\${loadingId}-error\`,
       title: 'Error',
       content: 'Something went wrong. Please try again.',
-      icon: <AlertCircle />
+      bubbleIcon: <AlertCircle />
     });
   }
 };`,


### PR DESCRIPTION
## Summary
- clarify loading and bubble behavior in README
- replace deprecated `icon` property with `bubbleIcon` in Examples page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c0423214832987223cbd65b4b491