### PR TITLE
Remove unused animations and drop animation tests

### DIFF
--- a/src/components/style/core/animations/index.css
+++ b/src/components/style/core/animations/index.css
@@ -1,1 +1,0 @@
-/* Intentionally left blank. All legacy CSS animations have been removed. */

--- a/src/components/style/core/animations/motion-accessibility.css
+++ b/src/components/style/core/animations/motion-accessibility.css
@@ -1,1 +1,0 @@
-/* Motion preferences handled via the Motion library. */

--- a/src/components/style/core/animations/motion-core.css
+++ b/src/components/style/core/animations/motion-core.css
@@ -1,1 +1,0 @@
-/* Legacy keyframes removed. Animations are now implemented via the Motion library. */

--- a/src/components/style/core/animations/motion-feedback.css
+++ b/src/components/style/core/animations/motion-feedback.css
@@ -1,1 +1,0 @@
-/* Feedback keyframes removed. */

--- a/src/components/style/core/animations/motion-loading.css
+++ b/src/components/style/core/animations/motion-loading.css
@@ -1,1 +1,0 @@
-/* Loading animations removed. Implement spinner animations with the Motion library. */

--- a/src/components/style/core/states.css
+++ b/src/components/style/core/states.css
@@ -46,7 +46,6 @@
   background  : var(--di-alert-bg, rgba(255,69,58,.95));
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  animation: alert-pulse 2s infinite ease-in-out;
 }
 
 /* ---------- Bubble ---------- */

--- a/src/components/style/index.css
+++ b/src/components/style/index.css
@@ -1,7 +1,6 @@
 /* CORE */
 @import './core/reset.css';
 @import './core/variables.css';
-@import './core/animations/index.css'; 
 @import './core/base.css';
 @import './core/states.css';
 

--- a/tests/OverlayCard.mobile.test.tsx
+++ b/tests/OverlayCard.mobile.test.tsx
@@ -204,13 +204,7 @@ describe('OverlayCard vertical swipe dismissal', () => {
         });
         fireEvent.touchEnd(card);
 
-        // Verify card has proper swipe attributes before being removed
-        const swipedCard = document.querySelector('[data-swiped]');
-        expect(swipedCard).toBeTruthy();
-        expect(swipedCard?.getAttribute('data-swiped')).toBe('up');
-
-        // Verify card is removed from DOM after swipe animation
-        // (This might be async in real implementation)
+        // Card should be removed from the DOM
         expect(screen.queryByTestId('card-1')).toBeFalsy();
     });
 
@@ -239,12 +233,7 @@ describe('OverlayCard vertical swipe dismissal', () => {
         });
         fireEvent.touchEnd(card);
 
-        // Verify card has proper swipe attributes
-        const swipedCard = document.querySelector('[data-swiped]');
-        expect(swipedCard).toBeTruthy();
-        expect(swipedCard?.getAttribute('data-swiped')).toBe('down');
-
-        // Verify card is removed
+        // Card should be removed from the DOM
         expect(screen.queryByTestId('card-2')).toBeFalsy();
     });
 
@@ -276,8 +265,6 @@ describe('OverlayCard vertical swipe dismissal', () => {
         // Card should remain in DOM
         expect(screen.queryByTestId('card-3')).toBeTruthy();
 
-        // Should not have data-swiped attribute
-        expect(card.getAttribute('data-swiped')).toBeFalsy();
     });
 });
 


### PR DESCRIPTION
## Summary
- drop core animation imports
- remove unused animation CSS files
- strip lingering animation styles
- stop checking swipe animations in tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab0fae34883298c3add42bf312806