### PR TITLE
Fix missing OverlayPortalProps export

### DIFF
--- a/src/components/core/portal/OverlayPortal.tsx
+++ b/src/components/core/portal/OverlayPortal.tsx
@@ -9,7 +9,7 @@ import useAggregator from '../../state/hooks/useAggregator';
 import { OverlayCard as DefaultCardUI } from '../card/OverlayCard';
 import '../../style/index.css';
 
-interface OverlayPortalProps {
+export interface OverlayPortalProps {
     concurrencyMode?: 'single' | 'multiple';
     portalRoot?: HTMLElement;
     unstyled?: boolean;


### PR DESCRIPTION
## Summary
- export `OverlayPortalProps` so motion components can import it

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab0b36d188329b1e5303d947500fc