### PR TITLE
Remove CSS sizing and hover effects

### DIFF
--- a/src/components/style/common/interactions.css
+++ b/src/components/style/common/interactions.css
@@ -6,16 +6,12 @@
 
 /* Interactive element hover effect */
 .interactive-hover {
-    transition: transform var(--di-duration-normal) var(--di-spring-timing-subtle);
 }
 
 .interactive-hover:hover {
-    transform: scale(var(--di-hover-scale, 1.03));
 }
 
 .interactive-hover:active {
-    transform: scale(var(--di-active-scale, 0.97));
-    transition: transform var(--di-duration-fast) var(--di-ease-out);
 }
 
 /* Focus states for accessibility */

--- a/src/components/style/components/overlay-actions.css
+++ b/src/components/style/components/overlay-actions.css
@@ -20,13 +20,9 @@
   font-size: 18px;
   padding: var(--overlay-padding-sm, 8px);
   cursor: pointer;
-  transition: opacity var(--di-duration-fast, 200ms) var(--di-ease-out);
 }
 
 @media (hover:hover) and (pointer:fine) {
-  :where(.overlay-styled .overlay-card-remove:hover) {
-    opacity: .7;
-  }
 }
 
 /* ---------- Swipe buttons (prev / next) ---------- */
@@ -38,14 +34,9 @@
   padding: var(--overlay-padding-sm, 8px) var(--overlay-padding-md, 12px);
   border-radius: var(--di-border-radius);
   cursor: pointer;
-  transition: background var(--di-duration-fast, 200ms) var(--di-ease-out);
 }
 
 @media (hover:hover) and (pointer:fine) {
-  :where(.overlay-styled .overlay-card-swipe-prev:hover,
-         .overlay-styled .overlay-card-swipe-next:hover) {
-    background: var(--overlay-secondary-color);
-  }
 }
 
 :where(.overlay-styled .overlay-card-swipe-prev:disabled,

--- a/src/components/style/components/overlay-card/base.css
+++ b/src/components/style/components/overlay-card/base.css
@@ -21,12 +21,8 @@
   gap          : var(--overlay-gap-sm, 6px);
   padding      : var(--overlay-padding-md, 12px);
 
-  /* Transform baseline (collapsed scale) */
+  /* Transform baseline */
   transform-origin: center;
-  transform       : scale(var(--di-scale-collapsed));
-  --di-scale-current: var(--di-scale-collapsed);
-
-  /* Transition removed */
 
   /* GPU hint – applied only while animating via JS */
   will-change: transform, opacity;

--- a/src/components/style/components/overlay-card/components.css
+++ b/src/components/style/components/overlay-card/components.css
@@ -19,15 +19,12 @@
   backdrop-filter: blur(var(--di-glass-blur, 20px));
   -webkit-backdrop-filter: blur(var(--di-glass-blur, 20px));
 
-  block-size: var(--overlay-collapsed-height, 44px);
   /* Transition removed */
 }
 
 /* ---------- Stand‑alone bubble (clickable) ---------- */
 :where(.overlay-styled .overlay-card-bubble) {
   --_size: var(--overlay-collapsed-height, 44px);
-  inline-size: var(--_size);
-  block-size : var(--_size);
   border-radius: 50%;
   display: grid;
   place-content: center;
@@ -45,8 +42,6 @@
 
 /* ---------- Loading spinner ---------- */
 :where(.overlay-styled .overlay-card-spinner) {
-  inline-size: 18px;
-  block-size : 18px;
   border: 2px solid rgba(255,255,255,.3);
   border-inline-start-color: #fff;   /* top in LTR / right in RTL */
   border-radius: 50%;
@@ -56,8 +51,6 @@
 /* ---------- Generic action button ---------- */
 :where(.overlay-styled .overlay-card-button) {
   --_btn-size: var(--overlay-btn-size, 36px);
-  inline-size: var(--_btn-size);
-  block-size : var(--_btn-size);
   display: grid;
   place-content: center;
   border-radius: 50%;

--- a/src/components/style/components/overlay-card/interactions.css
+++ b/src/components/style/components/overlay-card/interactions.css
@@ -7,34 +7,6 @@
 
 /* ---------- Desktop‑class pointers only ---------- */
 @media (hover:hover) and (pointer:fine) {
-  :where(.overlay-styled .overlay-card:hover) {
-    /* scale from token, preserve current state scale */
-    transform: scale(calc(var(--di-scale-current, 1) * var(--di-hover-scale, 1.03)));
-    box-shadow: var(--di-shadow-hover, 0 12px 32px rgba(0,0,0,.45));
-    border-color: var(--di-glass-border, rgba(255,255,255,.15));
-  }
-
-  :where(.overlay-styled .overlay-card:active) {
-    transform: scale(calc(var(--di-scale-current, 1) * var(--di-active-scale, 0.97)));
-    box-shadow: 0 5px 10px rgba(0,0,0,.20), 0 2px 3px rgba(0,0,0,.10);
-  }
-
-  /* Action buttons (remove / swipe) */
-  :where(.overlay-styled .overlay-card-remove:hover,
-         .overlay-styled .overlay-card-swipe-prev:hover,
-         .overlay-styled .overlay-card-swipe-next:hover) {
-    background: rgba(255,255,255,.20);
-    transform: scale(1.05);
-  }
-
-  :where(.overlay-styled .overlay-card-remove:hover) {
-    background: var(--di-alert-bg, rgba(255,69,58,.98));
-  }
-
-  /* Split layout: widen gap on hover */
-  :where(.overlay-styled .overlay-card--split:hover) {
-    gap: var(--overlay-gap-lg, 14px);
-  }
 }
 
 /* ---------- Focus ring (always on) ---------- */

--- a/src/components/style/components/overlay-card/responsive.css
+++ b/src/components/style/components/overlay-card/responsive.css
@@ -7,22 +7,13 @@
 
 @media (max-width: 576px) {
   /* Expanded card fills most of the viewport width on phones */
-  :where(.overlay-styled .overlay-card--expanded) {
-    inline-size: 95vw;
-    max-block-size: 80vh;
-  }
+  :where(.overlay-styled .overlay-card--expanded) {}
 
   /* Icon downsizing */
-  :where(.overlay-styled .overlay-card-icon) {
-    inline-size: 16px;
-    block-size : 16px;
-  }
+  :where(.overlay-styled .overlay-card-icon) {}
 
   /* Bubble (remove / swipe) touch targets */
-  :where(.overlay-styled .overlay-card-bubble) {
-    inline-size: calc(var(--overlay-collapsed-height, 44px) - 4px);
-    block-size : calc(var(--overlay-collapsed-height, 44px) - 4px);
-  }
+  :where(.overlay-styled .overlay-card-bubble) {}
 
   /* Split variant – tighter gap */
   :where(.overlay-styled .overlay-card--split) {

--- a/src/components/style/components/overlay-card/states.css
+++ b/src/components/style/components/overlay-card/states.css
@@ -8,8 +8,6 @@
 /* ---------- Loading (circular) ---------- */
 :where(.overlay-styled .overlay-card--loading) {
   /* square bubble */
-  inline-size : var(--overlay-collapsed-height, 44px);
-  block-size  : var(--overlay-collapsed-height, 44px);
   border-radius: 50%;
   display: flex;
   place-content: center;
@@ -18,8 +16,6 @@
 
 /* ---------- Collapsed (pill) ---------- */
 :where(.overlay-styled .overlay-card--collapsed) {
-  inline-size : var(--overlay-collapsed-width, 160px);
-  block-size  : var(--overlay-collapsed-height, 44px);
   border-radius: calc(var(--overlay-collapsed-height, 44px) / 2);
   padding: var(--overlay-padding-sm, 8px) var(--overlay-padding-md, 12px);
   transform-origin: center;
@@ -27,8 +23,6 @@
 
 /* ---------- Bubble ---------- */
 :where(.overlay-styled .overlay-card--bubble) {
-  inline-size : var(--overlay-collapsed-height, 44px);
-  block-size  : var(--overlay-collapsed-height, 44px);
   border-radius: 50%;
   display: flex;
   place-content: center;
@@ -37,8 +31,6 @@
 
 /* ---------- Split (pill + bubble) ---------- */
 :where(.overlay-styled .overlay-card--split) {
-  inline-size : calc(var(--overlay-collapsed-width, 160px) + var(--overlay-collapsed-height, 44px) + var(--overlay-gap-sm, 6px));
-  block-size  : var(--overlay-collapsed-height, 44px);
   border-radius: calc(var(--overlay-collapsed-height, 44px) / 2);
   padding: var(--overlay-padding-sm, 8px) var(--overlay-padding-md, 12px);
   gap: var(--overlay-gap-md, 10px);
@@ -47,9 +39,6 @@
 
 /* ---------- Expanded (card) ---------- */
 :where(.overlay-styled .overlay-card--expanded) {
-  inline-size : var(--overlay-expanded-width, 400px);
-  min-block-size: var(--overlay-expanded-height, 160px);
-  max-block-size: min(80vh, calc(var(--overlay-expanded-height,160px) * 2));
   padding: var(--overlay-padding-lg, 16px);
   flex-direction: column;
   justify-content: space-between;
@@ -79,7 +68,6 @@
 :where(.overlay-styled .overlay-card--expanded .overlay-card-body) {
   opacity: 1;
   overflow-y: auto;
-  max-block-size: min(60vh, calc(var(--overlay-expanded-height,160px) * 2));
   width: 100%;
   white-space: normal;
   margin: var(--overlay-gap-sm, 6px) 0;
@@ -108,12 +96,5 @@
 }
 
 /* ---------- Split bubble hover (already in interactions but required for motion safety) ---------- */
-:where(.overlay-styled .overlay-card--split:hover .overlay-card-split-bubble) {
-  transform: scale(0);
-}
 
 /* ---------- Loading spinner icon size ---------- */
-:where(.overlay-styled .overlay-card--loading .overlay-card-icon) {
-  inline-size: 24px;
-  block-size : 24px;
-}

--- a/src/components/style/components/overlay-portal/interactions.css
+++ b/src/components/style/components/overlay-portal/interactions.css
@@ -7,15 +7,10 @@
 /* ---------------- Hover / Focus -------------------- */
 /* Desktop-class pointers only */
 @media (hover:hover) and (pointer:fine) {
-  .overlay-styled .overlay-portal:hover,
-  .overlay-styled .overlay-portal:focus-visible {
-    transform: scale(calc(var(--di-scale-current, 1) * var(--di-hover-scale, 1.03)));
-  }
 }
 
 /* ---------------- Active / Press ------------------- */
 .overlay-styled .overlay-portal:active {
-  transform: scale(calc(var(--di-scale-current, 1) * var(--di-active-scale, 0.97)));
 }
 
 /* ---------------- Focus Ring (a11y) ---------------- */
@@ -26,11 +21,6 @@
 
 /* ---------------- Reduced-Motion ------------------- */
 @media (prefers-reduced-motion: reduce) {
-  .overlay-styled .overlay-portal:hover,
-  .overlay-styled .overlay-portal:focus-visible,
-  .overlay-styled .overlay-portal:active {
-    transform: scale(var(--di-scale-current, 1)); /* No bounce */
-  }
 }
 
 /* ---------------- Wrapper Overrides ---------------- */

--- a/src/components/style/components/overlay-portal/states.css
+++ b/src/components/style/components/overlay-portal/states.css
@@ -11,39 +11,26 @@
 
 /* === STATES === */
 .overlay-styled .overlay-portal[data-state='expanded'] {
-    transform: scale(var(--di-scale-expanded));
-    --di-scale-current: var(--di-scale-expanded);
     border-radius: var(--di-border-radius);
 }
 
 .overlay-styled .overlay-portal[data-state='collapsed'] {
-    transform: scale(var(--di-scale-collapsed));
-    --di-scale-current: var(--di-scale-collapsed);
     border-radius: calc(var(--overlay-collapsed-height) / 2);
 }
 
 .overlay-styled .overlay-portal[data-state='loading'],
 .overlay-styled .overlay-portal[data-state='bubble'] {
-    width: var(--overlay-collapsed-height);
-    height: var(--overlay-collapsed-height);
     border-radius: 50%;
-    transform: scale(var(--di-scale-collapsed));
-    --di-scale-current: var(--di-scale-collapsed);
 }
 
 .overlay-styled .overlay-portal[data-state='split'] {
-    width: calc(var(--overlay-collapsed-width) + var(--overlay-collapsed-height) + var(--overlay-gap-sm));
-    height: var(--overlay-collapsed-height);
     border-radius: calc(var(--overlay-collapsed-height) / 2);
-    transform: scale(var(--di-scale-collapsed));
-    --di-scale-current: var(--di-scale-collapsed);
 }
 
 /* Hidden state */
 .overlay-styled .overlay-portal[data-hidden='true'] {
     opacity: 0;
     visibility: hidden;
-    transform: scale(0.8);
     /* Transition removed */
 }
 

--- a/src/components/style/core/states.css
+++ b/src/components/style/core/states.css
@@ -4,11 +4,7 @@
 
 /* ---------- Base card ---------- */
 :where(.overlay-styled .overlay-card) {
-  /* one source of truth for core transition */
-  transition:
-    transform var(--di-duration-normal, .4s) var(--di-transition-timing, cubic-bezier(.4,0,.2,1)),
-    opacity   var(--di-duration-fast,   .2s) ease-out,
-    visibility 0s linear;
+  /* Core styles only – animations handled via Motion */
 }
 
 /* ---------- Expanded ---------- */
@@ -29,19 +25,11 @@
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transform: translateY(-100%);
-  inline-size : var(--overlay-collapsed-width, 120px);
-  block-size  : var(--overlay-collapsed-height, 36px);
-  transition:                                         /* delayed visibility hide */
-    opacity     var(--di-duration-fast, .2s)   ease-out,
-    transform   var(--di-duration-normal, .4s) ease-out,
-    visibility  0s linear var(--di-duration-normal, .4s);
+  /* Transition removed – handled via Motion */
 }
 
 /* ---------- Alert ---------- */
 :where(.overlay-styled .overlay-card--alert) {
-  inline-size : var(--overlay-collapsed-width ,120px);
-  block-size  : var(--overlay-collapsed-height, 36px);
   border-radius: calc(var(--overlay-collapsed-height, 36px) / 2);
   background  : var(--di-alert-bg, rgba(255,69,58,.95));
   backdrop-filter: none;
@@ -51,8 +39,6 @@
 /* ---------- Bubble ---------- */
 :where(.overlay-styled .overlay-card--bubble) {
   --_bubble-size: var(--overlay-collapsed-height, 36px);
-  inline-size : var(--_bubble-size);
-  block-size  : var(--_bubble-size);
   border-radius: 50%;
   display: flex;
   place-content: center;
@@ -68,17 +54,12 @@
 
 :where(.overlay-styled .overlay-card-split-bubble) {
   --_bubble-size: var(--overlay-collapsed-height, 36px);
-  inline-size : var(--_bubble-size);
-  block-size  : var(--_bubble-size);
   border-radius: 50%;
   display: flex;
   place-content: center;
-  transition: transform var(--di-duration-normal, .4s) var(--di-spring-timing, cubic-bezier(.34,1.56,.64,1));
+  /* Transition removed – handled via Motion */
 }
 
-:where(.overlay-styled .overlay-card--split:hover .overlay-card-split-bubble) {
-  transform: scale(0);
-}
 
 /* ---------- Motion safety ---------- */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- drop leftover transform and sizing rules across overlay CSS modules
- strip interactive hover styles now handled by Motion

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9e712b308329b41efbe42594a5f9