### PR TITLE
Remove static CSS motion

### DIFF
--- a/src/components/style/components/overlay-card/base.css
+++ b/src/components/style/components/overlay-card/base.css
@@ -21,11 +21,7 @@
   gap          : var(--overlay-gap-sm, 6px);
   padding      : var(--overlay-padding-md, 12px);
 
-  /* Transform baseline */
-  transform-origin: center;
-
-  /* GPU hint – applied only while animating via JS */
-  will-change: transform, opacity;
+  /* Transform baseline removed */
 }
 
 /* ---------- Content wrapper ---------- */

--- a/src/components/style/components/overlay-card/states.css
+++ b/src/components/style/components/overlay-card/states.css
@@ -18,7 +18,6 @@
 :where(.overlay-styled .overlay-card--collapsed) {
   border-radius: calc(var(--overlay-collapsed-height, 44px) / 2);
   padding: var(--overlay-padding-sm, 8px) var(--overlay-padding-md, 12px);
-  transform-origin: center;
 }
 
 /* ---------- Bubble ---------- */
@@ -44,7 +43,6 @@
   justify-content: space-between;
   align-items: stretch;
   gap: var(--overlay-gap-md, 10px);
-  transform-origin: top center;
   overflow: visible;
   /* Animation removed */
 }

--- a/src/components/style/core/states.css
+++ b/src/components/style/core/states.css
@@ -61,14 +61,6 @@
 }
 
 
-/* ---------- Motion safety ---------- */
-@media (prefers-reduced-motion: reduce) {
-  :where(.overlay-styled .overlay-card-split-bubble),
-  :where(.overlay-styled .overlay-card--split:hover .overlay-card-split-bubble) {
-    transition: none;
-    transform: none;
-  }
-}
 
 /* ---------- Mobile tweak ---------- */
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- clean up overlay-card CSS declarations
- rely solely on Motion components for animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac502b3f08329bf5025abf5f627c3