### PR TITLE
Fix portal overflow & remove interaction styles

### DIFF
--- a/src/components/style/common/interactions.css
+++ b/src/components/style/common/interactions.css
@@ -4,16 +4,6 @@
    - Hover, active, and focus states
 ========================================================== */
 
-/* Interactive element hover effect */
-.interactive-hover {
-}
-
-.interactive-hover:hover {
-}
-
-.interactive-hover:active {
-}
-
 /* Focus states for accessibility */
 .focus-outline:focus-visible {
     outline: 2px solid var(--overlay-focus-ring, rgba(0, 122, 255, 0.8));

--- a/src/components/style/components/overlay-actions.css
+++ b/src/components/style/components/overlay-actions.css
@@ -22,29 +22,4 @@
   cursor: pointer;
 }
 
-@media (hover:hover) and (pointer:fine) {
-}
-
-/* ---------- Swipe buttons (prev / next) ---------- */
-:where(.overlay-styled .overlay-card-swipe-prev,
-       .overlay-styled .overlay-card-swipe-next) {
-  background: var(--overlay-primary-color);
-  color: #fff;
-  font-size: var(--overlay-font-size-md, 16px);
-  padding: var(--overlay-padding-sm, 8px) var(--overlay-padding-md, 12px);
-  border-radius: var(--di-border-radius);
-  cursor: pointer;
-}
-
-@media (hover:hover) and (pointer:fine) {
-}
-
-:where(.overlay-styled .overlay-card-swipe-prev:disabled,
-       .overlay-styled .overlay-card-swipe-next:disabled) {
-  opacity: .4;
-  cursor: not-allowed;
-}
-
-/* Alignment helpers */
-:where(.overlay-styled .overlay-card-swipe-prev) { margin-inline-end: auto; }
-:where(.overlay-styled .overlay-card-swipe-next) { margin-inline-start: auto; }
+/* Swipe actions removed */

--- a/src/components/style/components/overlay-card/components.css
+++ b/src/components/style/components/overlay-card/components.css
@@ -22,7 +22,7 @@
   /* Transition removed */
 }
 
-/* ---------- Stand‑alone bubble (clickable) ---------- */
+/* ---------- Stand‑alone bubble ---------- */
 :where(.overlay-styled .overlay-card-bubble) {
   --_size: var(--overlay-collapsed-height, 44px);
   border-radius: 50%;
@@ -62,9 +62,7 @@
   /* Transition removed */
 }
 
-/* ---------- Specific actions (remove / swipe) ---------- */
-:where(.overlay-styled .overlay-card-remove,
-       .overlay-styled .overlay-card-swipe-prev,
-       .overlay-styled .overlay-card-swipe-next) {
+/* ---------- Remove button ---------- */
+:where(.overlay-styled .overlay-card-remove) {
   font-size: 16px;
 }

--- a/src/components/style/components/overlay-card/interactions.css
+++ b/src/components/style/components/overlay-card/interactions.css
@@ -5,9 +5,7 @@
    so we avoid accidental triggers on touch devices.
    ===================================================== */
 
-/* ---------- Desktop‑class pointers only ---------- */
-@media (hover:hover) and (pointer:fine) {
-}
+/* Pointer interactions removed */
 
 /* ---------- Focus ring (always on) ---------- */
 :where(.overlay-styled .overlay-card:focus-visible) {

--- a/src/components/style/components/overlay-card/responsive.css
+++ b/src/components/style/components/overlay-card/responsive.css
@@ -12,9 +12,6 @@
   /* Icon downsizing */
   :where(.overlay-styled .overlay-card-icon) {}
 
-  /* Bubble (remove / swipe) touch targets */
-  :where(.overlay-styled .overlay-card-bubble) {}
-
   /* Split variant – tighter gap */
   :where(.overlay-styled .overlay-card--split) {
     gap: var(--overlay-gap-sm, 6px);

--- a/src/components/style/components/overlay-card/states.css
+++ b/src/components/style/components/overlay-card/states.css
@@ -93,6 +93,4 @@
   box-shadow: 0 8px 24px rgba(255, 69, 58, .4), 0 2px 8px rgba(255,69,58,.3);
 }
 
-/* ---------- Split bubble hover (already in interactions but required for motion safety) ---------- */
-
 /* ---------- Loading spinner icon size ---------- */

--- a/src/components/style/components/overlay-portal/base.css
+++ b/src/components/style/components/overlay-portal/base.css
@@ -21,7 +21,6 @@
   /* Animations */
   /* Transition removed */
   will-change: transform, opacity;
-  contain: paint;      
 }
 
 /* wrapper that does not mess with layout */

--- a/src/components/style/components/overlay-portal/interactions.css
+++ b/src/components/style/components/overlay-portal/interactions.css
@@ -4,14 +4,7 @@
 
 /* Transition removed */
 
-/* ---------------- Hover / Focus -------------------- */
-/* Desktop-class pointers only */
-@media (hover:hover) and (pointer:fine) {
-}
-
-/* ---------------- Active / Press ------------------- */
-.overlay-styled .overlay-portal:active {
-}
+/* Pointer-based interactions removed */
 
 /* ---------------- Focus Ring (a11y) ---------------- */
 .overlay-styled .overlay-portal:focus-visible {

--- a/src/components/style/core/base.css
+++ b/src/components/style/core/base.css
@@ -30,8 +30,16 @@
   gap: var(--overlay-gap-md, 12px);
   padding: var(--overlay-padding-md, 8px);
 
+  overflow: visible;
+  box-sizing: border-box;
+
   width: auto;
   max-inline-size: 90vw;         /* replaces max-width */
+}
+
+/* RTL support */
+:where([dir='rtl'] .overlay-container) {
+  direction: rtl;
 }
 
 /* ---------- Layout helpers ---------- */

--- a/src/components/style/core/reset.css
+++ b/src/components/style/core/reset.css
@@ -51,9 +51,9 @@
   outline-offset: 2px;
 }
 
-/* 7. Hide scrollbars on portals */
+/* 7. Ensure portal content is visible */
 :where(.overlay-library .overlay-portal) {
-  overflow: hidden;
+  overflow: visible;
 }
 
 /* 8. Motion safety */

--- a/src/components/style/core/variables.css
+++ b/src/components/style/core/variables.css
@@ -58,10 +58,6 @@
   --overlay-border-color       : rgba(0, 0, 0, 0.10);
   --overlay-border-width       : 1px;
 
-  /* --- Scale factors --- */
-  --di-scale-collapsed         : 1;
-  --di-scale-expanded          : calc(var(--overlay-expanded-width) / var(--overlay-collapsed-width));
-
   /* --- Durations --- */
   --di-duration-fast           : 200ms;
   --di-duration-normal         : 400ms;
@@ -85,11 +81,6 @@
     box-shadow    var(--di-duration-normal) var(--di-ease-out);
   /* backward compat */
   --overlay-transition         : var(--di-overlay-transition);
-
-  /* --- Interaction scaling --- */
-  --overlay-scale-hover        : 1.02; /* legacy */
-  --di-hover-scale             : 1.03;
-  --di-active-scale            : 0.97;
 
   /* --- Layering & Performance --- */
   --overlay-z-index            : 1000;


### PR DESCRIPTION
## Summary
- allow overlay containers to overflow and support RTL
- ensure portals don't hide overflow by default
- strip swipe and hover CSS; remove unused scale tokens

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run dev` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac69b0cc88329b1799fdad4b75c4c