### PR TITLE
Refactor MotionOverlayCard animation props

### DIFF
--- a/src/components/motion/MotionOverlayCard.tsx
+++ b/src/components/motion/MotionOverlayCard.tsx
@@ -1,17 +1,14 @@
 import React from 'react';
-import { motion } from "motion/react";
+import { motion } from 'motion/react';
 import useAggregator from '../state/hooks/useAggregator';
 import { OverlayCard } from '../core/card/OverlayCard';
 import type { OverlayCard as OverlayCardType } from '../state/types';
+import { variants, type OverlayState } from '../../motion/variants';
+import { prefersReducedMotion } from '../../motion/utils';
 
 interface MotionOverlayCardProps {
   channelId: string;
   card?: OverlayCardType;
-}
-
-function usePrefersReducedMotion() {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
 export default function MotionOverlayCard({ channelId, card }: MotionOverlayCardProps) {
@@ -19,20 +16,13 @@ export default function MotionOverlayCard({ channelId, card }: MotionOverlayCard
   const channel = state.channels[channelId];
   if (!channel) return null;
 
-  const reduceMotion = usePrefersReducedMotion();
-  const variants = {
-    collapsed: { scale: 0.95, opacity: 1 },
-    expanded: { scale: 1, opacity: 1 },
-    bubble: { scale: 0.9, opacity: 1 },
-    hidden: { scale: 0.8, opacity: 0 },
-  } as const;
-
-  const current = (channel.state in variants ? channel.state : 'collapsed') as keyof typeof variants;
+  const reduceMotion = prefersReducedMotion();
+  const currentState: OverlayState =
+    (channel.state in variants ? channel.state : 'collapsed') as OverlayState;
 
   return (
     <motion.div
-      variants={variants}
-      animate={reduceMotion ? false : current}
+      animate={reduceMotion ? undefined : variants[currentState]}
       initial={false}
       style={{ display: 'contents' }}
     >

--- a/src/motion/utils.ts
+++ b/src/motion/utils.ts
@@ -1,4 +1,4 @@
-import { useReducedMotion, type Variant } from 'motion';
+import { useReducedMotion, type Variant } from 'motion/react';
 
 export function prefersReducedMotion(): boolean {
     const shouldReduceMotion = useReducedMotion();


### PR DESCRIPTION
## Summary
- reuse shared overlay animation variants
- use `prefersReducedMotion` helper
- fix internal hook import for reduced motion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ade1ae6288329ba3458b637415466