### PR TITLE
Fix reduced motion hook

### DIFF
--- a/src/components/core/LoadingIndicator.tsx
+++ b/src/components/core/LoadingIndicator.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import { motion } from "motion/react";
 import '../style/components/loading-indicator.css';
-
-function usePrefersReducedMotion() {
-    if (typeof window === 'undefined') return false;
-    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-}
+import { prefersReducedMotion } from '../../motion/utils';
 
 export default function LoadingIndicator() {
-    const reduceMotion = usePrefersReducedMotion();
+    const reduceMotion = prefersReducedMotion();
     return (
         <div className="loading-indicator" role="status" aria-label="Loading">
             <motion.div

--- a/src/components/motion/MotionOverlayPortal.tsx
+++ b/src/components/motion/MotionOverlayPortal.tsx
@@ -1,16 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { motion } from "motion/react"
 import { OverlayPortal, OverlayPortalProps } from '../core/portal';
-
-function usePrefersReducedMotion() {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-}
+import { prefersReducedMotion } from '../../motion/utils';
 
 export default function MotionOverlayPortal(props: OverlayPortalProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [root, setRoot] = useState<HTMLElement | null>(null);
-  const reduceMotion = usePrefersReducedMotion();
+  const reduceMotion = prefersReducedMotion();
 
   useEffect(() => {
     if (ref.current) setRoot(ref.current);
@@ -19,9 +15,9 @@ export default function MotionOverlayPortal(props: OverlayPortalProps) {
   return (
     <motion.div
       ref={ref}
-      initial={{ opacity: 0, y: 10 }}
-      animate={reduceMotion ? { opacity: 1, y: 0 } : { opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 10 }}
+      initial={reduceMotion ? false : { opacity: 0, y: 10 }}
+      animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+      exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 10 }}
     >
       {root && <OverlayPortal {...props} portalRoot={root} />}
     </motion.div>


### PR DESCRIPTION
## Summary
- reuse `prefersReducedMotion` hook from `motion/utils`
- disable portal animations if reduced motion is preferred

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae03efd588329a388f41f98fbd732