### PR TITLE
Add motion entrypoint

### DIFF
--- a/src/components/core/LoadingIndicator.tsx
+++ b/src/components/core/LoadingIndicator.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { motion } from "motion/react";
 import '../style/components/loading-indicator.css';
-import { prefersReducedMotion } from '../../motion/utils';
+import { prefersReducedMotion } from '../../motion';
 
 export default function LoadingIndicator() {
     const reduceMotion = prefersReducedMotion();

--- a/src/components/motion/MotionOverlayCard.tsx
+++ b/src/components/motion/MotionOverlayCard.tsx
@@ -3,8 +3,7 @@ import { motion } from 'motion/react';
 import useAggregator from '../state/hooks/useAggregator';
 import { OverlayCard } from '../core/card/OverlayCard';
 import type { OverlayCard as OverlayCardType } from '../state/types';
-import { variants, type OverlayState } from '../../motion/variants';
-import { prefersReducedMotion } from '../../motion/utils';
+import { variants, type OverlayState, prefersReducedMotion } from '../../motion';
 
 interface MotionOverlayCardProps {
   channelId: string;

--- a/src/components/motion/MotionOverlayPortal.tsx
+++ b/src/components/motion/MotionOverlayPortal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { motion } from "motion/react"
 import { OverlayPortal, OverlayPortalProps } from '../core/portal';
-import { prefersReducedMotion } from '../../motion/utils';
+import { prefersReducedMotion } from '../../motion';
 
 export default function MotionOverlayPortal(props: OverlayPortalProps) {
   const ref = useRef<HTMLDivElement>(null);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ import './components/style/index.css';
 export { default as Floatify } from './components/core/Floatify';
 export { default as useAggregator } from './components/state/hooks/useAggregator';
 export * from './components/motion';
+export * from './motion';

--- a/src/motion/index.ts
+++ b/src/motion/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Consolidated exports for motion-related utilities and animation variants.
+ */
+
+/** Animation presets keyed by overlay state. */
+export { variants } from './variants';
+
+/** Overlay state keys used by the variants. */
+export type { OverlayState, Variant } from './variants';
+
+/** Utility for creating a variant with full type safety. */
+export { createVariant } from './utils';
+
+/** Detects if the user prefers reduced motion. */
+export { prefersReducedMotion } from './utils';


### PR DESCRIPTION
## Summary
- expose motion utils via `src/motion/index.ts`
- re-export motion utilities from the package index
- update internal imports to use new motion index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae1322f348329a2cac9940d46d810